### PR TITLE
API call added, image2png

### DIFF
--- a/backend/routers/converters.py
+++ b/backend/routers/converters.py
@@ -47,25 +47,16 @@ async def pdf2png(file: UploadFile = File(...), page_number: int = 1):
 #known good formats: .bmp, .dds, .gif, .ico, .jpe, .jpeg, .jpg, .tiff, .cr2, .dng, .jfif, .nef, .webp
 @router.post('/image2png')
 async def image2png(file: UploadFile = File(...)):
+    # file types that PIL can't convert to png, but have image headers
+    unsupported_types = ['image/svg+xml', 'image/ERF', 'image/NRW', 'image/ORF', 'image/PEF', 'image/RAF', 'image/RW2']
+    
     #failsafe checks
     if not file.content_type.startswith('image/'):
         raise HTTPException(status_code=400, detail='File must be an image')
     if file.content_type == 'image/png':
         raise HTTPException(status_code=400, detail='File is already a .png file')
-    if file.content_type == 'image/svg+xml':
-        raise HTTPException(status_code=400, detail='File is an SVG file, which is not supported')
-    if file.content_type == 'image/ERF':
-        raise HTTPException(status_code=400, detail='File is an ERF file, which is not supported')
-    if file.content_type == 'image/NRW':
-        raise HTTPException(status_code=400, detail='File is an NRW file, which is not supported')
-    if file.content_type == 'image/ORF':
-        raise HTTPException(status_code=400, detail='File is an ORF file, which is not supported')
-    if file.content_type == 'image/PEF':
-        raise HTTPException(status_code=400, detail='File is an PEF file, which is not supported')
-    if file.content_type == 'image/RAF':
-        raise HTTPException(status_code=400, detail='File is an RAF file, which is not supported')
-    if file.content_type == 'image/RW2':
-        raise HTTPException(status_code=400, detail='File is an RW2 file, which is not supported')
+    if file.content_type in unsupported_types:
+        raise HTTPException(status_code=400, detail=f'File is a {file.content_type} file, which is not supported')
     
     #create a temporary file to store input image
     temp_image = tempfile.NamedTemporaryFile(delete=False)

--- a/backend/routers/converters.py
+++ b/backend/routers/converters.py
@@ -1,10 +1,13 @@
 # API router for file conversion
+import os
 
 from fastapi import APIRouter, File, UploadFile, HTTPException
 from fastapi.responses import FileResponse
 
 from pdf2image import convert_from_path
 import tempfile
+
+from PIL import Image
 
 #from ..modules import converter
 
@@ -40,4 +43,46 @@ async def pdf2png(file: UploadFile = File(...), page_number: int = 1):
     #return image
     return FileResponse(temp_image.name, media_type='image/png', filename=image_name)
 
+#route to convert several image formats to .png
+#known good formats: .bmp, .dds, .gif, .ico, .jpe, .jpeg, .jpg, .tiff, .cr2, .dng, .jfif, .nef, .webp
+@router.post('/image2png')
+async def image2png(file: UploadFile = File(...)):
+    #failsafe checks
+    if not file.content_type.startswith('image/'):
+        raise HTTPException(status_code=400, detail='File must be an image')
+    if file.content_type == 'image/png':
+        raise HTTPException(status_code=400, detail='File is already a .png file')
+    if file.content_type == 'image/svg+xml':
+        raise HTTPException(status_code=400, detail='File is an SVG file, which is not supported')
+    if file.content_type == 'image/ERF':
+        raise HTTPException(status_code=400, detail='File is an ERF file, which is not supported')
+    if file.content_type == 'image/NRW':
+        raise HTTPException(status_code=400, detail='File is an NRW file, which is not supported')
+    if file.content_type == 'image/ORF':
+        raise HTTPException(status_code=400, detail='File is an ORF file, which is not supported')
+    if file.content_type == 'image/PEF':
+        raise HTTPException(status_code=400, detail='File is an PEF file, which is not supported')
+    if file.content_type == 'image/RAF':
+        raise HTTPException(status_code=400, detail='File is an RAF file, which is not supported')
+    if file.content_type == 'image/RW2':
+        raise HTTPException(status_code=400, detail='File is an RW2 file, which is not supported')
+    
+    #create a temporary file to store input image
+    temp_image = tempfile.NamedTemporaryFile(delete=False)
+    temp_image.write(await file.read())
+    temp_image.close()
 
+    #making the name of the image, used for the return
+    image_name = os.path.splitext(file.filename)[0] + '.png'
+
+    #convert image to png
+    image = Image.open(temp_image.name)
+    png_image = image.convert('RGB')
+
+    #create a temporary PNG to store the converted image
+    temp_png = tempfile.NamedTemporaryFile(delete=False)
+    png_image.save(temp_png.name, 'PNG')
+    temp_png.close()
+
+    #return PNG
+    return FileResponse(temp_png.name, media_type='image/png', filename=image_name)


### PR DESCRIPTION
Added an API call called "image2png", which converts image files to PNG. PNG is not converted, as there's no need.
Known good file types are:
_.bmp, .cr2, .dds, .dng, .gif, .ico, .jfif, .jpe, .jpeg, .jpg, .nef, .tiff, .webp_

Known formats that are not converted are:
_.cur, .erf, .exr, .fts, .hdr, .heic, .heif, .jp2, .jps, .mng, .nrw, .orf, .pam, .pbm, .pcd, .pcx, .pef, .pes, .pfm, .pgm, .picon, .pict, .png, .pnm, .ppm, .psd, .raf, .ras, .rw2, .sgi, .svg, .tga, .wbmp, .xpm_
