### PR TITLE
Uploading a file is sent to the backend for conversion and returned

### DIFF
--- a/frontend/app/Conversion/page.tsx
+++ b/frontend/app/Conversion/page.tsx
@@ -1,0 +1,105 @@
+'use client';
+import { useRouter } from 'next/navigation'
+import { useState, useEffect } from 'react';
+import Conversion from '../../components/component/conversion';
+import UploadFile from '../../components/component/upload-file';
+import axios from 'axios';
+
+export default function Page() {
+    const router = useRouter();
+
+    // Initialize pdfData state variable
+    const [pdfData, setPdfData] = useState<string | null>(null);
+
+    // Convert Image or PDF to PNG after component has been rendered on the client side.
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            const pdfDataFromLocalStorage = window.localStorage.getItem('pdfData');
+
+            // Check if pdfData is already in local storage
+            if (pdfDataFromLocalStorage !== null) {
+                // Parse the data from local storage
+                const parsedData = JSON.parse(pdfDataFromLocalStorage);
+                setPdfData(parsedData);
+
+                // Fetch the Blob from the URL
+                fetch(parsedData.url)
+                .then(res => res.blob())
+                .then(blob => {
+                    const formData = new FormData();
+                    formData.append('file', blob, '');
+
+                    // Get the file type
+                    const fileType = parsedData.type;
+
+                    // This has a lot of duplication, should perhaps be refactored
+                    if (fileType === 'application/pdf') {
+                        // Make API call for PDF file
+                        axios.post('http://localhost:8000/converter/pdf2png', formData, {
+                            headers: {
+                                'Content-Type': 'multipart/form-data'
+                            },
+                            responseType: 'blob' // Tell axios to expect a Blob
+                        }).then(response => {
+                            // Create a Blob URL from the returned file
+                            const fileURL = URL.createObjectURL(response.data);
+
+                            // Save the Blob URL to local storage
+                            window.localStorage.setItem('pdfData', fileURL);
+
+                            //push to Editor
+                            router.push('/Editor');
+                        }).catch(error => {
+                            if (error.response && error.response.status === 400) {
+                                goToUpload("The file you uploaded is not supported.");
+                            }
+                        });
+                    } else if (fileType === 'image/png') {
+                        // Create a Blob URL from the fetched Blob
+                        const fileURL = URL.createObjectURL(blob);
+
+                        // Save the Blob URL to local storage
+                        window.localStorage.setItem('pdfData', fileURL);
+
+                        //push to Editor
+                        router.push('/Editor');
+                    } else if (fileType.startsWith('image/')) {
+                        // Make a different API call for other image files
+                        axios.post('http://localhost:8000/converter/image2png', formData, {
+                            headers: {
+                                'Content-Type': 'multipart/form-data'
+                            },
+                            responseType: 'blob' // Tell axios to expect a Blob
+                        }).then(response => {
+                            // Create a Blob URL from the returned file
+                            const fileURL = URL.createObjectURL(response.data);
+
+                            // Save the Blob URL to local storage
+                            window.localStorage.setItem('pdfData', fileURL);
+
+                            //push to Editor
+                            router.push('/Editor');
+                        }).catch(error => {
+                            // This is mainly added in case the user uploads a file with a header that starts with image/, 
+                            // but is not supported by the backend, e.g. SVG
+                            if (error.response && error.response.status === 400) {
+                                goToUpload("The file you uploaded is not supported.");
+                            }
+                        });
+                    }
+                });
+            }
+        }
+    }, []);
+
+    // Function to push to UploadFile with an error message
+    function goToUpload(string = 'An error occurred.') {
+        router.push('/?e=' + string);
+    }
+
+    return (
+        <main>
+            {pdfData !== null ? <Conversion /> : <UploadFile />}
+        </main>
+    );
+}

--- a/frontend/components/component/conversion.tsx
+++ b/frontend/components/component/conversion.tsx
@@ -1,0 +1,16 @@
+import { RotateLoader } from 'react-spinners';
+
+export default function Conversion() {
+    return (
+        <div className="flex flex-col h-screen bg-white">
+            <div className="mx-auto mt-10 max-w-xl">
+                <div className="rounded-lg border-4 border-dashed border-blue-200 p-10 py-20 text-center">
+                    <div className="p-10 text-center text-gray-400">
+                        <h1>Getting your file ready</h1>
+                    </div>
+                    <RotateLoader color="#9CA3AF"/>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/components/component/upload-file.tsx
+++ b/frontend/components/component/upload-file.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 export default function UploadFile() {
 
@@ -9,6 +9,14 @@ export default function UploadFile() {
 	const router = useRouter()
 	const [fileType, setFileType] = useState('');
 	const [fileName, setFileName] = useState('');
+	const params = useSearchParams();
+
+
+	useEffect(() => {
+		if (params.get("e")) {
+			setErrorMessage(params.get("e") as string);
+		}
+	});
 
 	// Handle file input change when user has used "Open a file"-button
 	const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -43,7 +51,10 @@ export default function UploadFile() {
 			const reader = new FileReader();
 			reader.onload = () => {
 				const blob = new Blob([reader.result as string], { type: file.type });
-				localStorage.setItem('pdfData', URL.createObjectURL(blob));
+				localStorage.setItem('pdfData', JSON.stringify({
+					url: URL.createObjectURL(blob),
+					type: blob.type
+				}));
 			};
 			reader.readAsArrayBuffer(file);
 
@@ -53,8 +64,8 @@ export default function UploadFile() {
 				localStorage.removeItem('pdfData');
 			}
 
-			//push to Editor
-			router.push('/Editor');
+			//Push to Conversion, where the file will be converted to PNG
+			router.push('/Conversion');
 			
 		} else {
 			setErrorMessage('File type not supported.');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@types/mapbox-gl": "^2.7.20",
     "@windmill/react-ui": "^0.6.0",
     "allotment": "^1.20.0",
+    "axios": "^1.6.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "lucide-react": "^0.309.0",
@@ -28,6 +29,7 @@
     "react-image-crop": "^11.0.5",
     "react-map-gl": "^7.1.7",
     "react-map-gl-geocoder": "^2.2.0",
+    "react-spinners": "^0.13.8",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
     "urql": "^4.0.6"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -869,6 +869,15 @@ axe-core@=4.7.0:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz"
   integrity sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==
 
+axios@^1.6.7:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
+  integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
+  dependencies:
+    follow-redirects "^1.15.4"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz"
@@ -1785,6 +1794,11 @@ focus-trap@^6.7.3:
   dependencies:
     tabbable "^5.3.3"
 
+follow-redirects@^1.15.4:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
+  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz"
@@ -1804,6 +1818,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -3307,6 +3330,11 @@ protocol-buffers-schema@^3.3.1:
   resolved "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz"
   integrity sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz"
@@ -3407,6 +3435,11 @@ react-map-gl@^7.1.7:
   dependencies:
     "@maplibre/maplibre-gl-style-spec" "^19.2.1"
     "@types/mapbox-gl" ">=1.0.0"
+
+react-spinners@^0.13.8:
+  version "0.13.8"
+  resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.13.8.tgz#5262571be0f745d86bbd49a1e6b49f9f9cb19acc"
+  integrity sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==
 
 react-transition-group@4.4.1:
   version "4.4.1"


### PR DESCRIPTION
Added a middle route, "/Conversion".
When uploading a file, it is then sent to the backend to be converted, and then pushed to the editor as a PNG.
PNGs are skipped, other image types and PDFs are being converted.
Error on upload page can be set from another route (due to SVG having a header that starts with image/, but is not accepted in the backend)