### PR TITLE
Fixed large images not being cropped correctly

### DIFF
--- a/frontend/components/component/imageEdit.tsx
+++ b/frontend/components/component/imageEdit.tsx
@@ -16,56 +16,79 @@ export default function ImageEdit({ editBool, onCrop }: { editBool: boolean, onC
             return;
         }
 
-        // Set the coordinates for the top-left corner, and calculate the coordinates of the bottom-right corner
-        // (Values need to be rounded to the nearest whole number to avoid issues with the API.)
-        const p1x = Math.round(crop.x);
-        const p1y = Math.round(crop.y)
-        const p2x = Math.round(crop.x + crop.width);
-        const p2y = Math.round(crop.y + crop.height);
-
-        // Fetch the Blob from the blob URL
-        const response = await fetch(imageSrc);
-        const blob = await response.blob();
-
-        // Create a FormData and add the blob file
-        const formData = new FormData();
-        formData.append('file', blob, 'filename');
-
-        //Try to send a request to the API
-        try {
-            // Send a POST request to the API with the coordinates and file
-            const response = await axios.post(`http://localhost:8000/converter/cropPng?p1x=${p1x}&p1y=${p1y}&p2x=${p2x}&p2y=${p2y}`, formData, {
-                headers: {
-                    'Content-Type': 'multipart/form-data'
-                },
-                responseType: 'blob' // Tell axios to expect a Blob in the response
-            });
-
-            // Convert the response data to a Blob
-            const newBlob = new Blob([response.data], { type: 'image/png' });
-
-            // Convert the new Blob to a Blob URL
-            const blobUrl = URL.createObjectURL(newBlob);
-
-            // Update the source URL of the image
-            window.localStorage.setItem("pdfData", blobUrl);
-            
-            // Tell the current component and parent component that the image has been cropped
-            setImageSrc(localStorage.getItem("pdfData")!);
-            onCrop();
-
-            // Reset the crop state, use max width and height
-            setCrop({
-                unit: '%',
-                x: 0,
-                y: 0,
-                width: 100,
-                height: 100,
-            });
-        } catch (error) {
-            // Log any errors
-            console.error('Error:', error);
+        // Get the displayed image size
+        const imageElement = document.querySelector('img');
+        if (!imageElement) {
+            console.log("No image element found!");
+            return;
         }
+        const displayedWidth = imageElement.clientWidth;
+        const displayedHeight = imageElement.clientHeight;
+
+        // Get the original image for comparison
+        const originalImage = new Image();
+        originalImage.onload = async () => {
+            // Get the original image size
+            const originalWidth = originalImage.width;
+            const originalHeight = originalImage.height;
+
+            // Calculate the scale factor
+            const scaleFactorX = originalWidth / displayedWidth;
+            const scaleFactorY = originalHeight / displayedHeight;
+
+            // Set the coordinates for the top-left corner, and calculate the coordinates of the bottom-right corner.
+            // Then scale the coordinates to the original image size.
+            // (Values need to be rounded to the nearest whole number to avoid issues with the API.)
+            const p1x = Math.round(crop.x * scaleFactorX);
+            const p1y = Math.round(crop.y * scaleFactorY);
+            const p2x = Math.round((crop.x + crop.width) * scaleFactorX);
+            const p2y = Math.round((crop.y + crop.height) * scaleFactorY);
+
+            // Fetch the Blob from the blob URL
+            const response = await fetch(imageSrc);
+            const blob = await response.blob();
+
+            // Create a FormData and add the blob file
+            const formData = new FormData();
+            formData.append('file', blob, 'filename');
+
+            //Try to send a request to the API
+            try {
+                // Send a POST request to the API with the coordinates and file
+                const response = await axios.post(`http://localhost:8000/converter/cropPng?p1x=${p1x}&p1y=${p1y}&p2x=${p2x}&p2y=${p2y}`, formData, {
+                    headers: {
+                        'Content-Type': 'multipart/form-data'
+                    },
+                    responseType: 'blob' // Tell axios to expect a Blob in the response
+                });
+
+                // Convert the response data to a Blob
+                const newBlob = new Blob([response.data], { type: 'image/png' });
+
+                // Convert the new Blob to a Blob URL
+                const blobUrl = URL.createObjectURL(newBlob);
+
+                // Update the source URL of the image
+                window.localStorage.setItem("pdfData", blobUrl);
+                
+                // Tell the current component and parent component that the image has been cropped
+                setImageSrc(localStorage.getItem("pdfData")!);
+                onCrop();
+
+                // Reset the crop state, use max width and height
+                setCrop({
+                    unit: '%',
+                    x: 0,
+                    y: 0,
+                    width: 100,
+                    height: 100,
+                });
+            } catch (error) {
+                // Log any errors
+                console.error('Error:', error);
+            }
+        };
+        originalImage.src = imageSrc;
 
         
     };


### PR DESCRIPTION
Fixed large images not being cropped directly. This is done by loading in the original image, and scaling up the (downsized) crop preview to the original image size