### PR TITLE
Fixed no project return when points empty

### DIFF
--- a/backend/img2mapAPI/utils/projectHandler.py
+++ b/backend/img2mapAPI/utils/projectHandler.py
@@ -116,7 +116,10 @@ class ProjectHandler:
         if project is None:
             raise Exception("Project not found")
         #check for project points
-        points = await self.getProjectPoints(projectId)
+        try:
+            points = await self.getProjectPoints(projectId)
+        except:
+            points = []
         #make pointlist object and add the points to the project
         pointList = PointList()
         for point in points:


### PR DESCRIPTION
the API call for getting a project now returns the project with empty points list instead of a points error message.