### PR TITLE
Implement Map Tile Generation and Serve Tiles via Mapbox Requests

### DIFF
--- a/backend/img2mapAPI/routers/georefProject.py
+++ b/backend/img2mapAPI/routers/georefProject.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, File, UploadFile, HTTPException, BackgroundTasks 
+from fastapi import APIRouter, File, UploadFile, HTTPException, BackgroundTasks, Path
 from fastapi.responses import FileResponse, Response
 from typing import List
 #internal imports:
@@ -11,6 +11,15 @@ from ..utils.storage.data.storageHandler import StorageHandler
 from ..utils.storage.data.localStorage import LocalStorage
 from ..devOnly.georefTestFiles.testproject import createTestProject as cts #test function
 from ..devOnly.localrepository.repository import Repository
+
+from PIL import Image
+import io
+from rio_tiler.io import Reader
+from rio_tiler.errors import TileOutsideBounds
+from rio_tiler.models import ImageData
+from rio_tiler.utils import render
+import numpy as np
+
 
 router = APIRouter(
     prefix="/project",
@@ -186,3 +195,39 @@ async def getCornerCoordinates(projectId: int):
         return cornerCoordinates
     except Exception as e:
         raise HTTPException(status_code=404, detail=str(e))
+
+blanke_tile = Image.new('RGBA', (256, 256), (255, 255, 255, 0))
+bytes_io = io.BytesIO()
+blanke_tile.save(bytes_io, format='PNG')
+blank_tile_bytes = bytes_io.getvalue()
+
+@router.get("/{projectId}/tiles/{z}/{x}/{y}.png", response_class=Response)
+async def get_tile(projectId: int, z: int, x: int, y: int):
+    try:
+        tiff_path = await _projectHandler.getGeoreferencedFilePath(projectId)
+        
+        with Reader(tiff_path) as src:
+            tile, mask = src.tile(x, y, z)
+            
+            # Correct the shapes
+            tile = np.moveaxis(tile, 0, -1)  # Move bands to the last axis to get shape (height, width, 3)
+            mask = np.expand_dims(mask, axis=-1)  # Add an axis to mask to get shape (height, width, 1)
+
+            # Stack tile and mask arrays along the last axis
+            data = np.concatenate((tile, mask), axis=-1)
+            
+            # Convert numpy array to PIL Image
+            img = Image.fromarray(data, 'RGBA')
+
+            # Convert PIL Image to bytes
+            img_byte_arr = io.BytesIO()
+            img.save(img_byte_arr, format='PNG')
+            img_byte_arr.seek(0)
+
+            return Response(content=img_byte_arr.getvalue(), media_type="image/png")
+    except TileOutsideBounds:
+        # Return the blank tile for out-of-bounds requests
+        return Response(content=blank_tile_bytes, media_type="image/png")
+    except Exception as e:
+        # Handle unexpected errors
+        return Response(status_code=500, content=f"An unexpected error occurred: {str(e)}")

--- a/backend/img2mapAPI/routers/georefProject.py
+++ b/backend/img2mapAPI/routers/georefProject.py
@@ -16,8 +16,6 @@ from PIL import Image
 import io
 from rio_tiler.io import Reader
 from rio_tiler.errors import TileOutsideBounds
-from rio_tiler.models import ImageData
-from rio_tiler.utils import render
 import numpy as np
 
 

--- a/backend/img2mapAPI/utils/core/georefHelper.py
+++ b/backend/img2mapAPI/utils/core/georefHelper.py
@@ -4,6 +4,7 @@ import rasterio as rio #importing rasterio for georeferencing
 from rasterio.transform import from_gcps #importing from_gcps to create a transform from GCPs
 from rasterio.control import GroundControlPoint as GCP 
 from rasterio.crs import CRS #importing CRS for the default crs
+from rasterio.enums import Resampling #importing Resampling for the overview levels
 from ..models import PointList #importing the pointList model
 from .FileHelper import getUniqeFileName, removeFile #importing the getUniqeFileName and removeFile functions from FileHelper
 
@@ -87,6 +88,15 @@ def InitialGeoreferencePngImage(tempFilePath, points: PointList, crs: str = defa
     transform = from_gcps(gcps) #create the transform
     dataset.transform = transform #set the transform
     dataset.crs = CRS.from_string(crs) #set the crs
+
+    #define overview levels
+    #is needed for generating the map tiles
+    overview_levels = [2, 4, 8, 16]
+    dataset.build_overviews(overview_levels, Resampling.nearest) #build the overviews
+    #update tags
+    dataset.update_tags(ns='rio_overview', resampling='nearest') #update the tags
+
+    #close the file
     dataset.close()
 
     removeFile(filename) #removing the temporary file
@@ -121,6 +131,13 @@ def reGeoreferencedImageTiff(innFilePath, points: PointList, crs: str = defaultC
     transform = from_gcps(gcps) #create the transform
     dataset.transform = transform #set the transform
     dataset.crs = CRS.from_string(crs) #set the crs
+
+    #define overview levels
+    #is needed for generating the map tiles
+    overview_levels = [2, 4, 8, 16]
+    dataset.build_overviews(overview_levels, Resampling.nearest) #build the overviews
+    #update tags
+    dataset.update_tags(ns='rio_overview', resampling='nearest') #update the tags
     dataset.close() #close the file
 
     return filename

--- a/backend/img2mapAPI/utils/core/georefHelper.py
+++ b/backend/img2mapAPI/utils/core/georefHelper.py
@@ -8,6 +8,13 @@ from rasterio.enums import Resampling #importing Resampling for the overview lev
 from ..models import PointList #importing the pointList model
 from .FileHelper import getUniqeFileName, removeFile #importing the getUniqeFileName and removeFile functions from FileHelper
 
+from fastapi.responses import Response #importing Response for the tile generation
+import io #importing io for byte operations
+from rio_tiler.io import Reader #importing the rio_tiler reader
+from rio_tiler.errors import TileOutsideBounds #Error returned by rio_tiler when the requested tile is outside the bounds
+import numpy as np #importing numpy for array operations
+from PIL import Image #importing PIL for image operations
+
 warnings.filterwarnings("ignore", category=rio.errors.NotGeoreferencedWarning) #ignore the not georeferenced warning
 defaultCrs = 'EPSG:4326'
 
@@ -163,3 +170,36 @@ def getCornerCoordinates(tiff_path):
         bottom_left = (bounds.left, bounds.bottom)
 
         return [top_left, top_right, bottom_right, bottom_left]
+
+blanke_tile = Image.new('RGBA', (256, 256), (255, 255, 255, 0))
+bytes_io = io.BytesIO()
+blanke_tile.save(bytes_io, format='PNG')
+blank_tile_bytes = bytes_io.getvalue()
+
+async def generateTile(tiff_path, x: int, y: int, z: int):
+    try:
+        with Reader(tiff_path) as src:
+                tile, mask = src.tile(x, y, z)
+                
+                # Correct the shapes
+                tile = np.moveaxis(tile, 0, -1)  # Move bands to the last axis to get shape (height, width, 3)
+                mask = np.expand_dims(mask, axis=-1)  # Add an axis to mask to get shape (height, width, 1)
+
+                # Stack tile and mask arrays along the last axis
+                data = np.concatenate((tile, mask), axis=-1)
+                
+                # Convert numpy array to PIL Image
+                img = Image.fromarray(data, 'RGBA')
+
+                # Convert PIL Image to bytes
+                img_byte_arr = io.BytesIO()
+                img.save(img_byte_arr, format='PNG')
+                img_byte_arr.seek(0)
+
+        return Response(content=img_byte_arr.getvalue(), media_type="image/png")
+    except TileOutsideBounds:
+        return Response(content=blank_tile_bytes, media_type="image/png")
+    except Exception as e:
+        print(e)
+        raise e
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,5 +5,6 @@ rasterio
 python-multipart
 pdf2image
 setuptools
+rio-tiler
 
 ###### Requirements with Version Specifiers ######

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -11,7 +11,7 @@ setup(
         'rasterio',
         'python-multipart',
         'pdf2image',
-        'rio_tiler',
+        'rio-tiler',
     ],
     classifiers=[
         # https://pypi.org/classifiers/

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -11,6 +11,7 @@ setup(
         'rasterio',
         'python-multipart',
         'pdf2image',
+        'rio_tiler',
     ],
     classifiers=[
         # https://pypi.org/classifiers/

--- a/frontend/components/component/overlayview.tsx
+++ b/frontend/components/component/overlayview.tsx
@@ -16,25 +16,14 @@ const OverlayView = ({ projectId }: MapOverlayProps) => {
     [0, 0],
     [0, 0],
   ]);
-  const northEastLngLat = [cornerCoordinates[1][0], cornerCoordinates[1][1]];
-  const southWestLngLat = [cornerCoordinates[3][0], cornerCoordinates[3][1]];
+
+  var [bounds, setBounds] = useState([0, 0, 0, 0]);
+
   const [dataUrl, setDataUrl] = useState("");
   const [imageSrc, setImageSrc] = useState(localStorage.getItem("pdfData")!);
 
   const baseURL = "http://localhost:8000";
   useEffect(() => {
-    async function fetchCornerCoordinates() {
-      try {
-        const coordinatesResponse = await axios.get(
-          `${baseURL}/project/${projectId}/georef/coordinates`
-        );
-        const coords = coordinatesResponse.data;
-        setCornerCoordinates(coords);
-      } catch (error) {
-        console.error("Error fetching corner coordinates:", error);
-      }
-    }
-
     fetch(imageSrc)
       .then((response) => response.blob())
       .then((blob) => {
@@ -48,8 +37,7 @@ const OverlayView = ({ projectId }: MapOverlayProps) => {
       .catch((error) =>
         console.error("Error converting blob URL to data URL:", error)
       );
-    fetchCornerCoordinates();
-  }, [projectId]);
+  }, [projectId, imageSrc]);
 
   return (
     <div className="w-full h-full">
@@ -57,6 +45,13 @@ const OverlayView = ({ projectId }: MapOverlayProps) => {
         style={{ width: "100%", height: "100%" }}
         mapStyle="mapbox://styles/mapbox/streets-v11"
         mapboxAccessToken={mapboxToken}
+        initialViewState={{
+          latitude: 58.145,
+          longitude: 8,
+          zoom: 12,
+        }}
+        minZoom={5}
+        maxZoom={19}
       >
         {dataUrl && (
           <Source
@@ -64,9 +59,6 @@ const OverlayView = ({ projectId }: MapOverlayProps) => {
             type="raster"
             tiles={[`${baseURL}/project/${projectId}/tiles/{z}/{x}/{y}.png`]}
             tileSize={256}
-            // sets the bounds of the image to the corner coordinates
-            // stops requests for tiles outside of the bounds
-            bounds={[...southWestLngLat, ...northEastLngLat]}
           >
             <Layer
               id="georeferenced-image-layer"

--- a/frontend/components/component/overlayview.tsx
+++ b/frontend/components/component/overlayview.tsx
@@ -16,6 +16,8 @@ const OverlayView = ({ projectId }: MapOverlayProps) => {
     [0, 0],
     [0, 0],
   ]);
+  const northEastLngLat = [cornerCoordinates[1][0], cornerCoordinates[1][1]];
+  const southWestLngLat = [cornerCoordinates[3][0], cornerCoordinates[3][1]];
   const [dataUrl, setDataUrl] = useState("");
   const [imageSrc, setImageSrc] = useState(localStorage.getItem("pdfData")!);
 
@@ -53,9 +55,9 @@ const OverlayView = ({ projectId }: MapOverlayProps) => {
     <div className="w-full h-full">
       <Map
         initialViewState={{
-          longitude: cornerCoordinates[0][0],
-          latitude: cornerCoordinates[0][1],
-          zoom: 3,
+          latitude: 58,
+          longitude: 8,
+          zoom: 10,
         }}
         style={{ width: "100%", height: "100%" }}
         mapStyle="mapbox://styles/mapbox/streets-v11"
@@ -64,16 +66,18 @@ const OverlayView = ({ projectId }: MapOverlayProps) => {
         {dataUrl && (
           <Source
             id="georeferenced-image-source"
-            type="image"
-            url={dataUrl}
-            coordinates={cornerCoordinates}
+            type="raster"
+            tiles={[`${baseURL}/project/${projectId}/tiles/{z}/{x}/{y}.png`]}
+            tileSize={256}
+            // sets the bounds of the image to the corner coordinates
+            // stops requests for tiles outside of the bounds
+            bounds={[...southWestLngLat, ...northEastLngLat]}
           >
             <Layer
               id="georeferenced-image-layer"
               source="georeferenced-image-source"
               type="raster"
               raster-opacity={1}
-              raster-resampling="linear"
             />
           </Source>
         )}

--- a/frontend/components/component/overlayview.tsx
+++ b/frontend/components/component/overlayview.tsx
@@ -11,7 +11,6 @@ interface MapOverlayProps {
 const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 
 const OverlayView = ({ projectId }: MapOverlayProps) => {
-  
   var [bounds, setBounds] = useState([0, 0, 0, 0]);
 
   const [dataUrl, setDataUrl] = useState("");
@@ -20,7 +19,7 @@ const OverlayView = ({ projectId }: MapOverlayProps) => {
 
   const handleOpacity = (value: number) => {
     setOpacity(value);
-  }
+  };
 
   const baseURL = "http://localhost:8000";
   useEffect(() => {
@@ -64,7 +63,7 @@ const OverlayView = ({ projectId }: MapOverlayProps) => {
               id="georeferenced-image-layer"
               source="georeferenced-image-source"
               type="raster"
-              paint={{ "raster-opacity": opacity / 100}}
+              paint={{ "raster-opacity": opacity / 100 }}
             />
           </Source>
         )}

--- a/frontend/components/component/overlayview.tsx
+++ b/frontend/components/component/overlayview.tsx
@@ -54,11 +54,6 @@ const OverlayView = ({ projectId }: MapOverlayProps) => {
   return (
     <div className="w-full h-full">
       <Map
-        initialViewState={{
-          latitude: 58,
-          longitude: 8,
-          zoom: 10,
-        }}
         style={{ width: "100%", height: "100%" }}
         mapStyle="mapbox://styles/mapbox/streets-v11"
         mapboxAccessToken={mapboxToken}


### PR DESCRIPTION
### Major changes include:

#### Map Tile Generation and Serving:
- Added functionality to generate map tiles dynamically based on requests from Mapbox. This allows us to serve custom tiles to the Mapbox map component.

#### Dependency Adjustments:
- Introduced `rio_tiler` as a new dependency to facilitate efficient tile generation. This library provides a robust set of tools for working with raster data and will be integral to our tile-serving backend.

### Testing:
- Tested the tile generation endpoint with a variety of map zoom levels and coordinates to ensure reliability and performance. (Needs more testing)
- Ensured that the `OverlayView` component updates correctly with varying project IDs and coordinates.