### PR TITLE
Automatic georeferencing and validation for buttons

### DIFF
--- a/frontend/components/component/editor.tsx
+++ b/frontend/components/component/editor.tsx
@@ -122,6 +122,8 @@ export default function Editor() {
   const handleToggleCoordTable = () => {
     setIsCoordList((prevIsCoordList) => !prevIsCoordList); // Toggle the value of isCoordTable
   };
+  // Condtition to check if there are atleast 3 markers to display the coordinates table and the values are not 0
+  const isGeorefValid = georefMarkerPairs.length >= 3 && georefMarkerPairs.every((pair) => pair.latLong.every((val) => val !== 0)) && georefMarkerPairs.every((pair) => pair.pixelCoords.every((val) => val !== 0));
 
   return (
     <div className="flex flex-col h-screen bg-white">
@@ -153,6 +155,7 @@ export default function Editor() {
             className="bg-gray-200 dark:bg-gray-700 hover:bg-blue-800 dark:hover:bg-blue-800"
             variant="secondary"
             onClick={handleToggleOverlay}
+            disabled={!isGeorefValid}
           >
             <WindowsIcon className="text-gray-500" />
             Overlay
@@ -178,7 +181,11 @@ export default function Editor() {
             Crop
           </Button>
         </div>
-        <UserDownload projectId={projectId}></UserDownload>
+        <UserDownload
+          projectId={projectId}
+          isDisabled={!isGeorefValid}
+          >
+        </UserDownload>
         <Button
           className="bg-gray-200 dark:bg-gray-700 dark:hover:bg-blue-800 dark:text-white"
           onClick={handleSave}

--- a/frontend/components/component/split-view.tsx
+++ b/frontend/components/component/split-view.tsx
@@ -217,6 +217,11 @@ export default function SplitView({
       lastPair.pixelCoords[0] !== 0 &&
       lastPair.pixelCoords[1] !== 0;
 
+    
+const hasEnoughEntries =
+      georefMarkerPairs.length >= 3 &&
+      georefMarkerPairs.every(pair => pair.latLong.every(val => val !== 0) &&
+      pair.pixelCoords.every(val => val !== 0));
     // Only proceed if the last pair is valid and an API call has not been made for the current set
     if (isValidPair && !apiCallMade.current) {
       apiCallMade.current = true; // Block further API calls for the current set of marker pairs
@@ -241,7 +246,14 @@ export default function SplitView({
           apiCallMade.current = false;
           setWaitingForImageMarker(false);
           setWaitingForMapMarker(false);
-        });
+
+        if (hasEnoughEntries) {
+          setHelpMessage(
+            "All pairs added! The map has been georeferenced"
+          );
+          handleGeoref();
+        }
+      });
     }
   }, [georefMarkerPairs, projectId]); // Depend on georefMarkerPairs to automatically re-trigger when they change
 
@@ -263,9 +275,6 @@ export default function SplitView({
       <div className=""></div>
       <div className="flex justify-center">
         <div className="fixed w-2/5 z-50 m-4 text-center">
-          <Button className="m-4" variant={"blue"} onClick={handleGeoref}>
-            Start Georeferencing
-          </Button>
           <Alert variant={"help"} className="">
             <AlertDescription>{helpMessage}</AlertDescription>
           </Alert>

--- a/frontend/components/component/userDownload.tsx
+++ b/frontend/components/component/userDownload.tsx
@@ -3,9 +3,10 @@ import { Button } from "@/components/ui/button";
 
 interface UserDownloadProps {
     projectId: number;
+    isDisabled: boolean;
 }
 
-const UserDownload = ({ projectId }: UserDownloadProps) => {
+const UserDownload = ({ projectId, isDisabled }: UserDownloadProps) => {
 
 
     const handleDownload = () => {
@@ -26,6 +27,7 @@ const UserDownload = ({ projectId }: UserDownloadProps) => {
                 size="default"
                 asChild={false}
                 onClick={handleDownload}
+                disabled={isDisabled}
                 >
                 Download
             </Button>


### PR DESCRIPTION
Notes:

- Added so that the user cannot use the overlay and download button when there are less that 3 points or one of the fields are empty
- Automatic georeferencing from when there are 3 entries or more and coordinates are filled out on both sides