### PR TITLE
API URL added to .env, and replaced hardcoded URLs

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,4 +3,4 @@ NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN="mapbox token"
 NEXT_PUBLIC_BACKEND_URL="http://{HOST}:{PORT}"
 
 # Urls that will make the page display PDF instead of Image in Image2Map
-NEXT_PUBLIC_PDF_URLS=["example.com, example2.com"]
+NEXT_PUBLIC_PDF_URLS=example1.com,example2.com

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,6 @@
 #exaple env file
 NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN="mapbox token"
-BACKEND_URL="http://{HOST}:{PORT}"
+NEXT_PUBLIC_BACKEND_URL="http://{HOST}:{PORT}"
+
+# Urls that will make the page display PDF instead of Image in Image2Map
+NEXT_PUBLIC_PDF_URLS=["example.com, example2.com"]

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -5,8 +5,8 @@ import './globals.css'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'PDF 2 Map',
-  description: 'Generated geographic data from PDFs',
+  title: 'Image 2 Map',
+  description: 'Georeference geographic data from Images and PDFs',
 }
 
 export default function RootLayout({

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,6 +2,7 @@
 import UploadPipeline from '@/components/component/uploadPipeline';
 import Navbar from '../components/ui/navbar';
 import { Suspense } from 'react';
+import ServiceName from '@/components/ui/return-service-name';
 
 export default function Home() {
   return (
@@ -25,13 +26,13 @@ export default function Home() {
           </div>
           <div className="2xl:w-3/4 p-6 card dark:bg-gray-800">
             <p className="text-lg text-secondary dark:text-gray-300">
-              Discover PDF/IMG2Map, the simplest solution for seamlessly georeferencing digital images and PDF files! 
+              Discover <ServiceName />, the simplest solution for seamlessly georeferencing digital images and PDF files! 
               Effortlessly upload your documents and pinpoint specific locations by selecting reference points on the image. 
               By embedding geospatial metadata, you can transform your files into geographically accurate representations, 
               perfect for urban planning, environmental analysis, or historical research. 
               <br /><br />
               Whether you're a GIS expert or new to spatial data, our intuitive platform makes georeferencing accessible to all. 
-              Start exploring the possibilities with PDF/IMG2Map today!
+              Start exploring the possibilities with <ServiceName /> today!
             </p>
           </div>
         </div>

--- a/frontend/components/component/conversion.tsx
+++ b/frontend/components/component/conversion.tsx
@@ -16,6 +16,9 @@ const Conversion: React.FC<ConversionProps> = ({ fileType, fileUrl, pageNumber, 
   const hasMadeApiCall = useRef(false);
   const [isLargeFile, setLargeFile] = useState<boolean>(false);
 
+  // Base URL for the backend API from .env
+  const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
+
 
   // Convert Image or PDF to PNG after component has been rendered on the client side.
   useEffect(() => {
@@ -56,10 +59,10 @@ const Conversion: React.FC<ConversionProps> = ({ fileType, fileUrl, pageNumber, 
               handleFileConversion(null, null, blob);
             } else if (fileType === "application/pdf") {
               // Make API call for PDF file
-              handleFileConversion(`http://localhost:8000/converter/pdf2png?page_number=${pageNumber || 1}`, formData);
+              handleFileConversion(`${BASE_URL}/converter/pdf2png?page_number=${pageNumber || 1}`, formData);
             } else if (fileType.startsWith("image/")) {
               // Make a different API call for other image files
-              handleFileConversion("http://localhost:8000/converter/image2png", formData);
+              handleFileConversion(`${BASE_URL}/converter/image2png`, formData);
             } else {
               goToUpload("The file you uploaded is not supported.");
             }

--- a/frontend/components/component/imageEdit.tsx
+++ b/frontend/components/component/imageEdit.tsx
@@ -67,10 +67,13 @@ export default function ImageEdit({ editBool, onCrop }: { editBool: boolean, onC
             const formData = new FormData();
             formData.append('file', blob, 'filename');
 
+            // Base URL for the backend API from .env
+            const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
+
             //Try to send a request to the API
             try {
                 // Send a POST request to the API with the coordinates and file
-                const response = await axios.post(`http://localhost:8000/converter/cropPng?p1x=${p1x}&p1y=${p1y}&p2x=${p2x}&p2y=${p2y}`, formData, {
+                const response = await axios.post(`${BASE_URL}/converter/cropPng?p1x=${p1x}&p1y=${p1y}&p2x=${p2x}&p2y=${p2y}`, formData, {
                     headers: {
                         'Content-Type': 'multipart/form-data'
                     },

--- a/frontend/components/component/overlayview.tsx
+++ b/frontend/components/component/overlayview.tsx
@@ -31,8 +31,10 @@ const OverlayView = ({ projectId }: MapOverlayProps) => {
     setMapStyle(style);
   };
 
+  // Base URL for the backend API from .env
+  const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
+
   // Converts the georeferenced image to a data URL
-  const baseURL = "http://localhost:8000";
   useEffect(() => {
     // Fetch the image as a blob url
     fetch(imageSrc)
@@ -91,7 +93,7 @@ const OverlayView = ({ projectId }: MapOverlayProps) => {
           <Source
             id="georeferenced-image-source"
             type="raster"
-            tiles={[`${baseURL}/project/${projectId}/tiles/{z}/{x}/{y}.png`]}
+            tiles={[`${BASE_URL}/project/${projectId}/tiles/{z}/{x}/{y}.png`]}
             tileSize={256}
           >
             <Layer

--- a/frontend/components/component/projectAPI.tsx
+++ b/frontend/components/component/projectAPI.tsx
@@ -19,7 +19,7 @@ interface ErrorResponse {
 }
 
 // Base URL for the backend API from .env
-const BASE_URL = process.env.BACKEND_URL;
+const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
 
 let hasMadeProjectApiCall = false;
 

--- a/frontend/components/component/projectAPI.tsx
+++ b/frontend/components/component/projectAPI.tsx
@@ -18,7 +18,8 @@ interface ErrorResponse {
   detail: string;
 }
 
-const BASE_URL = "http://localhost:8000";
+// Base URL for the backend API from .env
+const BASE_URL = process.env.BACKEND_URL;
 
 let hasMadeProjectApiCall = false;
 

--- a/frontend/components/ui/return-service-name.tsx
+++ b/frontend/components/ui/return-service-name.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 
-const Logo = () => {
-  const [logoText, setLogoText] = useState('Image'); // Default text
+const ServiceName = () => {
+  const [serviceText, setServiceText] = useState('Image'); // Default text
 
   // Array of domains that will make the logo show "PDF"
   const PDF_URLS = process.env.NEXT_PUBLIC_PDF_URLS ? process.env.NEXT_PUBLIC_PDF_URLS.split(',') : [];
@@ -9,15 +9,13 @@ const Logo = () => {
   useEffect(() => {
     // If the current host is in the array, change the text
     if (PDF_URLS.includes(window.location.host)) {
-      setLogoText('PDF');
+      setServiceText('PDF');
     }
   }, []);
 
   return (
-    <div className={`flex justify-center items-center text-l text-white`}>
-      <span><b>{logoText}</b> To Map</span>
-    </div>
+    <span>{serviceText} To Map</span>
   );
 };
 
-export default Logo;
+export default ServiceName;


### PR DESCRIPTION
- Added API base URL to .env
- Added URLs to .env that will make the service be named "PDF2Map" rather than "Image2Map"
- Replaced API URLs in code to use URL from .env
- Logo now displays PDF2Map from the domains in the list
- Added a component that returns either Image2Map or PDF2Map as text from the domains in the list