### PR TITLE
Add check for maximum zoom level in generateTile function

### DIFF
--- a/backend/img2mapAPI/utils/core/georefHelper.py
+++ b/backend/img2mapAPI/utils/core/georefHelper.py
@@ -171,12 +171,13 @@ def getCornerCoordinates(tiff_path):
 
         return [top_left, top_right, bottom_right, bottom_left]
 
-blanke_tile = Image.new('RGBA', (256, 256), (255, 255, 255, 0))
-bytes_io = io.BytesIO()
-blanke_tile.save(bytes_io, format='PNG')
-blank_tile_bytes = bytes_io.getvalue()
+
 
 async def generateTile(tiff_path, x: int, y: int, z: int):
+    blanke_tile = Image.new('RGBA', (256, 256), (255, 255, 255, 0))
+    bytes_io = io.BytesIO()
+    blanke_tile.save(bytes_io, format='PNG')
+    blank_tile_bytes = bytes_io.getvalue()
     # Check if the zoom level is greater than the maximum zoom level this stops computation of tiles that are too zoomed out
     # this is done to prevent the server from being overloaded when generating tiles that are too zoomed out
     MAX_ZOOM = 5

--- a/backend/img2mapAPI/utils/core/georefHelper.py
+++ b/backend/img2mapAPI/utils/core/georefHelper.py
@@ -177,6 +177,11 @@ blanke_tile.save(bytes_io, format='PNG')
 blank_tile_bytes = bytes_io.getvalue()
 
 async def generateTile(tiff_path, x: int, y: int, z: int):
+    # Check if the zoom level is greater than the maximum zoom level this stops computation of tiles that are too zoomed out
+    # this is done to prevent the server from being overloaded when generating tiles that are too zoomed out
+    MAX_ZOOM = 5
+    if z < MAX_ZOOM:
+        return Response(content=blank_tile_bytes, media_type="image/png")
     try:
         with Reader(tiff_path) as src:
                 tile, mask = src.tile(x, y, z)


### PR DESCRIPTION
Prevents tiles being requested when map is super zoomed out (value might need adjusting)