### PR TITLE
Moved when temp folder is cleared on BE startup

### DIFF
--- a/backend/img2mapAPI/Img2mapAPI.py
+++ b/backend/img2mapAPI/Img2mapAPI.py
@@ -2,7 +2,6 @@ from fastapi import FastAPI, APIRouter, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from img2mapAPI.routers import *
 from dotenv import load_dotenv, get_key
-from .utils.core.FileHelper import clearTmpFolder
 import os
 
 #setting the default environment to development
@@ -80,9 +79,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-# Clear files in the temp folder
-clearTmpFolder()
 
 # Default route
 @router.get("/")

--- a/backend/img2mapAPI/utils/storage/files/localFileStorage.py
+++ b/backend/img2mapAPI/utils/storage/files/localFileStorage.py
@@ -2,11 +2,15 @@ import os
 import shutil
 import tempfile
 from .fileStorage import FileStorage
+from ...core.FileHelper import clearTmpFolder
 from fastapi import UploadFile
 
 _tempPath = "./temp"
 if not os.path.exists(_tempPath):
     os.makedirs(_tempPath)
+
+# Clear files in the temp folder
+clearTmpFolder()
 
 #File storage using the local file system
 class LocalFileStorage(FileStorage):


### PR DESCRIPTION
Moved when and where temp folder is cleared when starting the backend. This fixes a bug accidentally introduced earlier, where the sub-temp folder would be created and then instantly deleted again on startup.