### PR TITLE
Fixed backend image duplication++

### DIFF
--- a/backend/img2mapAPI/utils/core/ImageHelper.py
+++ b/backend/img2mapAPI/utils/core/ImageHelper.py
@@ -39,13 +39,14 @@ async def image2png(file: UploadFile) -> Tuple[str, str]:
     """
     #local setup
     inputImage = getUniqeFileName('png')
-    image_name = file.filename[:-4] + '.png'
+    image_name = file.filename.rpartition('.')[0] + '.png'
     #save the image
     with open(inputImage, 'w+b') as img:
         img.write(await file.read())
     
     image = Image.open(inputImage)
     png_image = image.convert('RGB')
+    image.close()
     tempImage = getUniqeFileName('png')
     with open(tempImage, 'w+b') as img:
         png_image.save(img, 'PNG')

--- a/backend/img2mapAPI/utils/projectHandler.py
+++ b/backend/img2mapAPI/utils/projectHandler.py
@@ -344,10 +344,18 @@ class ProjectHandler:
         #only accept png
         if fileType.find("png") == -1:
             raise Exception(status_code=415, description="Invalid file type")
-        #save the image file
-        filePath = await self._FileStorage.saveFile(file, ".png")
-        #update the project with the file path
+        
+        #fetch the project
         project = await self._StorageHandler.fetchOne(projectId, "project")
+
+        #check if the project already has an image file, and remove it
+        if "imageFilePath" in project and project["imageFilePath"]:
+            await self._FileStorage.removeFile(project["imageFilePath"])
+
+        #save the new image file
+        filePath = await self._FileStorage.saveFile(file, ".png")
+
+        #update the project with the file path
         project["imageFilePath"] = filePath
         await self._StorageHandler.update(projectId, project, "project")
   
@@ -379,10 +387,18 @@ class ProjectHandler:
         #only accept tiff
         if fileType.find("tiff") == -1:
             raise Exception("Invalid file type")
+        
+        #fetch the project
+        project = await self._StorageHandler.fetchOne(projectId, "project")
+
+        #check if the project already has an image file, and remove it
+        if "georeferencedFilePath" in project and project["georeferencedFilePath"]:
+            await self.removeGeoreferencedFile(projectId)
+
         #save the georeferenced file
         filePath = await self._FileStorage.saveFile(file, ".tiff")
+
         #update the project with the file path
-        project = await self._StorageHandler.fetchOne(projectId, "project")
         project["georeferencedFilePath"] = filePath
         await self._StorageHandler.update(projectId, project, "project")
 
@@ -416,7 +432,7 @@ class ProjectHandler:
         """
         #remove the georeferenced file
         project = await self._StorageHandler.fetchOne(projectId, "project")
-        await self._FileStorage.remove(project["georeferencedFilePath"])
+        await self._FileStorage.removeFile(project["georeferencedFilePath"])
         #update the project with an empty file path
         project["georeferencedFilePath"] = ""
         await self._StorageHandler.update(projectId, project, "project")
@@ -464,13 +480,16 @@ class ProjectHandler:
             georeferencedImage = georef.InitialGeoreferencePngImage(imageFilePath, points, crs) #goreference the image, return the path to the georeferenced file
         if georeferencedImage is None:
             raise Exception("Image could not be georeferenced")
-        #save the georeferenced image open to bytes
-        filePath = await self._FileStorage.saveFileFromPath(georeferencedImage, ".tiff")
-        georef.removeFile(georeferencedImage) #clean up temps from georeferencing
+        
+        # Read the georeferenced image into bytes
+        georeferencedImageBytes = await self._FileStorage.readFile(georeferencedImage)
 
-        #update the project with the file path
-        project.georeferencedFilePath = filePath
-        await self.updateProject(project.id, project)
+        # Remove the temporary file
+        await self._FileStorage.removeFile(georeferencedImage)
+
+        # Save the georeferenced image
+        await self.saveGeoreferencedFile(projectId, georeferencedImageBytes, "tiff")
+
         
     async def georefTiffImage(self, projectId: int, crs: str = None) -> None:
         """


### PR DESCRIPTION
This PR includes several fixes to avoid file duplications and leftover files in the backend. It fixes a bug where some image files that should've been converted would cause an error. This PR also removes old images when new ones are created, such as cropped images or georeferenced images.

ImageHelper, image2png:
- Added a line to close image, fixes a bug where some files weren't converted (like .tiff or .gif)
- Made renaming file account for different length file endings (.tiff = 4, .gif = 3)

ProjectHandler:
- For both non-referenced and georeferenced images, when updating file path a check to see if an image already exists is made. If an image exists, it is then deleted before the new one is uploaded
- Fixed a bug where some temporary files weren't deleted