### PR TITLE
Deleting points through coordinate table

### DIFF
--- a/backend/img2mapAPI/utils/projectHandler.py
+++ b/backend/img2mapAPI/utils/projectHandler.py
@@ -236,13 +236,11 @@ class ProjectHandler:
         if points is None or points == []:
             point.Idproj = 1
         else:
-            iterator = 1
             point.Idproj = 1
-            for p in points:
-                if p["Idproj"] >= point.Idproj:
-                    iterator += 1
-                    point.Idproj += 1
-
+            ids = [p["Idproj"] for p in points]  # List of IDs taken from the database
+            while point.Idproj in ids:
+                point.Idproj += 1
+        
         #save the point to storage
         dbid = await self._StorageHandler.saveInStorage(point, "point", "id")
         if dbid is None:

--- a/frontend/components/component/coordinateList.tsx
+++ b/frontend/components/component/coordinateList.tsx
@@ -10,6 +10,7 @@ import Draggable from "react-draggable";
 import { DragHandleDots2Icon, CrossCircledIcon } from '@radix-ui/react-icons'
 import { useState } from "react";
 import { MinusCircledIcon } from '@radix-ui/react-icons'
+import { Button } from "@/components/ui/button";
 
 interface CoordinateListProps {
   georefMarkerPairs: GeorefMarkerPair[];
@@ -49,25 +50,22 @@ const CoordinateList: React.FC<CoordinateListProps> = ({ georefMarkerPairs, isHi
           <Table className="dark:bg-gray-700">
             <TableHeader>
               <TableRow>
-                <TableHead>Local ID</TableHead>
-                <TableHead>Backend ID</TableHead>
                 <TableHead>Longitude</TableHead>
                 <TableHead>Latitude</TableHead>
                 <TableHead>Map X</TableHead>
                 <TableHead>Map Y</TableHead>
+                <TableHead></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {georefMarkerPairs.map((pair, index) => (
                 <TableRow key={index}>
-                  <TableCell>{index}</TableCell>
-                  <TableCell>{pair.pointId}</TableCell>
                   <TableCell>{pair.latLong[0]}</TableCell>
                   <TableCell>{pair.latLong[1]}</TableCell>
                   <TableCell>{pair.pixelCoords[0]}</TableCell>
                   <TableCell>{pair.pixelCoords[1]}</TableCell>
                   <TableCell>
-                    <button className="text-red-500" onClick={handleDelete(pair.pointId, index)}>Delete</button>
+                    <Button className="bg-red-600 dark:bg-red-600 dark:text-white hover:bg-red-700 dark:hover:bg-red-700" onClick={handleDelete(pair.pointId, index)}>Delete</Button>
                   </TableCell>
                 </TableRow>
               ))}

--- a/frontend/components/component/coordinateList.tsx
+++ b/frontend/components/component/coordinateList.tsx
@@ -9,18 +9,27 @@ import {
 import Draggable from "react-draggable";
 import { DragHandleDots2Icon, CrossCircledIcon } from '@radix-ui/react-icons'
 import { useState } from "react";
+import { MinusCircledIcon } from '@radix-ui/react-icons'
 
 interface CoordinateListProps {
   georefMarkerPairs: GeorefMarkerPair[];
   isHidden: boolean;
   toggleHidden: () => void;
+  onDeleteMarker: (pointId: number | null, index: number) => void;
 }
 interface GeorefMarkerPair {
+  pointId: number | null;
   latLong: number[];
   pixelCoords: number[];
 }
 
-const CoordinateList: React.FC<CoordinateListProps> = ({ georefMarkerPairs, isHidden, toggleHidden }) => {
+const CoordinateList: React.FC<CoordinateListProps> = ({ georefMarkerPairs, isHidden, toggleHidden, onDeleteMarker }) => {
+  const handleDelete = (pointId: number | null, index: number) => {
+    return () => {
+      onDeleteMarker(pointId, index);
+    };
+  }
+  
   return (
       <Draggable bounds="body" handle=".handle" defaultClassName={`rounded-lg fixed max-w-2xl z-[999] top-20 right-2 ${isHidden ? 'hidden' : ''}`}>
         <div>
@@ -40,6 +49,8 @@ const CoordinateList: React.FC<CoordinateListProps> = ({ georefMarkerPairs, isHi
           <Table className="dark:bg-gray-700">
             <TableHeader>
               <TableRow>
+                <TableHead>Local ID</TableHead>
+                <TableHead>Backend ID</TableHead>
                 <TableHead>Longitude</TableHead>
                 <TableHead>Latitude</TableHead>
                 <TableHead>Map X</TableHead>
@@ -49,10 +60,15 @@ const CoordinateList: React.FC<CoordinateListProps> = ({ georefMarkerPairs, isHi
             <TableBody>
               {georefMarkerPairs.map((pair, index) => (
                 <TableRow key={index}>
+                  <TableCell>{index}</TableCell>
+                  <TableCell>{pair.pointId}</TableCell>
                   <TableCell>{pair.latLong[0]}</TableCell>
                   <TableCell>{pair.latLong[1]}</TableCell>
                   <TableCell>{pair.pixelCoords[0]}</TableCell>
                   <TableCell>{pair.pixelCoords[1]}</TableCell>
+                  <TableCell>
+                    <button className="text-red-500" onClick={handleDelete(pair.pointId, index)}>Delete</button>
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/frontend/components/component/editor.tsx
+++ b/frontend/components/component/editor.tsx
@@ -21,7 +21,7 @@ export default function Editor() {
 
   // Array containing pairs of georeferenced markers and their corresponding image markers
   const [georefMarkerPairs, setGeorefMarkerPairs] = useState<
-    { latLong: [number, number]; pixelCoords: [number, number] }[]
+    { pointId: number | null ; latLong: [number, number]; pixelCoords: [number, number] }[]
   >([]);
   const [mapMarkers, setMapMarkers] = useState<
     { geoCoordinates: [number, number] }[]
@@ -120,11 +120,27 @@ export default function Editor() {
   // Resets all marker arrays and disables overlay view
   const resetMarkerRequest = () => {
     console.log("Resetting markers...");
+    api.deleteAllMarkers(projectId);
     setGeorefMarkerPairs([]);
     setMapMarkers([]);
     setImageMarkers([]);
     setIsGeorefValid(false);
   };
+
+  function handleMarkerPairDelete(pointId: number | null, index: number): void {
+    // Delete the marker pair locally
+    console.log("Deleting marker pair at index", index+1);
+    setGeorefMarkerPairs(prevState => prevState.filter((_, i) => i !== index));
+    setMapMarkers(prevState => prevState.filter((_, i) => i !== index));
+    setImageMarkers(prevState => prevState.filter((_, i) => i !== index));
+    console.log(imageMarkers, mapMarkers, georefMarkerPairs);
+
+    // Return if no pointId is given, else proceed with API deletion
+    if (pointId === null) {
+      return;
+    }
+    api.deleteMarkerPair(projectId, pointId)
+  }
 
   // Handle download requests
   const handleDownload = () => {
@@ -160,6 +176,7 @@ export default function Editor() {
           setMapMarkers={setMapMarkers}
           imageMarkers={imageMarkers}
           setImageMarkers={setImageMarkers}
+          onDeleteMarker={handleMarkerPairDelete}
         />
       ) : activePage === 'overlay' ? (
         console.log("Overlay view requested"),
@@ -192,6 +209,7 @@ export default function Editor() {
           setMapMarkers={setMapMarkers}
           imageMarkers={imageMarkers}
           setImageMarkers={setImageMarkers}
+          onDeleteMarker={handleMarkerPairDelete}
         />
       )}
     </div>

--- a/frontend/components/component/projectAPI.tsx
+++ b/frontend/components/component/projectAPI.tsx
@@ -6,12 +6,13 @@ interface ProjectResponse {
 }
 
 interface MarkerPairResponse {
-  id: number;
-  lat: number;
-  lng: number;
-  col: number;
-  row: number;
-  name: string;
+  Project: {
+    id: number;
+  };
+  Point: {
+    id: number;
+    inProjectId: number;
+  };
 }
 
 interface ErrorResponse {
@@ -60,6 +61,7 @@ export const addMarkerPair = async (
         name: "",
       }
     );
+    console.log(response.data);
     return response.data;
   } catch (error) {
     throw new Error(getErrorMessage(error as AxiosError<ErrorResponse>));
@@ -145,6 +147,26 @@ export const deleteAllMarkers = async (projectId: number): Promise<void> => {
     throw new Error(getErrorMessage(error as AxiosError<ErrorResponse>));
   } finally {
     console.log("All markers deleted");
+  }
+};
+
+/**
+ * DELETE /project/{projectId}/point/{pointId}
+ * Deletes a marker pair from a project
+ * @param projectId - The ID of the project to delete the marker pair from
+ * @param pointId - The ID of the marker pair to delete
+ */
+export const deleteMarkerPair = async (projectId: number, pointId: number): Promise<void> => {
+  try {
+    await axios.delete(`${BASE_URL}/project/${projectId}/point/${pointId}`, {
+      headers: {
+        accept: "application/json",
+      },
+    });
+  } catch (error) {
+    throw new Error(getErrorMessage(error as AxiosError<ErrorResponse>));
+  } finally {
+    console.log("Marker pair deleted");
   }
 };
 

--- a/frontend/components/component/split-view.tsx
+++ b/frontend/components/component/split-view.tsx
@@ -297,7 +297,7 @@ export default function SplitView({
 
           if (hasEnoughEntries) {
             setHelpMessage(
-              "All pairs added! The map has been georeferenced, go to overlayview to see your georeferenced map"
+              "Enough pairs added! The map has been georeferenced, go to Overlay to see your map!"
             );
             handleGeoref();
           }


### PR DESCRIPTION
This PR adds functionality to delete placed marker pairs through the coordinate table. It also makes marker pairs keep track of the ID they have in the backend.

**Backend:**
ProjectHandler:
- Changed the way next point ID is found. It now takes the first available ID in the project. 

**Frontend:**
coordinateList:
- Added a Delete button for markers/marker-pairs
- Updated props as necessary

editor:
- Added a pointId entry to the georefMarkerPairs-array
- Added function "handleMarkerPairDelete". Takes a pointId (for the backend) and a index (local array index)
- Updated resetMarkerRequest to make API call to delete markers in DB when all markers are requested to be reset

projectAPI:
- Updated MarkerPairResponse interface to match returned data structure from backend.
- Added function "deleteMarkerPair". Takes projectId and pointId. Relatively self explanatory, deletes entry based on project and point ID.

split-view:
- When adding a new marker, pointId is set to null
- Added function "replaceLastMarkerId". Replaces pointId of newest entry in georefMarkerPairs.
- For a marker pair to be valid, the pointId must not be null. 
- If a marker pair is valid and added to the DB, replaceLastMarkerId is called using the new pointId in DB
- useEffect for API calls now listens for changes on mapMarkers and imageMarkers arrays rather than the marker pair array
- Updated props as necessary
- Changed help message when enough marker pairs have been added