### PR TITLE
Updated Updating Project Name

### DIFF
--- a/backend/img2mapAPI/utils/core/georefHelper.py
+++ b/backend/img2mapAPI/utils/core/georefHelper.py
@@ -95,6 +95,7 @@ def InitialGeoreferencePngImage(tempFilePath, points: PointList, crs: str = defa
     transform = from_gcps(gcps) #create the transform
     dataset.transform = transform #set the transform
     dataset.crs = CRS.from_string(crs) #set the crs
+    dataset.gcps = (gcps, crs) #set the gcps
 
     #define overview levels
     #is needed for generating the map tiles

--- a/frontend/components/component/editor.tsx
+++ b/frontend/components/component/editor.tsx
@@ -12,6 +12,7 @@ export type ViewPage = 'sideBySide' | 'overlay' | 'crop'; // Pages in the editor
 export default function Editor() {
   const [projectId, setProjectId] = useState(0);
   const [projectName, setProjectName] = useState("Project 1");
+  const [projectNameNormalized, setProjectNameNormalized] = useState("Project_1");
   const [projectNameMaxLength, setProjectNameMaxLength] = useState(32); // Max 32 characters for project name
   const [isAutoSaved, setIsAutoSaved] = useState(false);
   const [imageSrc, setImageSrc] = useState(localStorage.getItem("pdfData")!); // Keeps track of image URL
@@ -148,7 +149,7 @@ export default function Editor() {
   const handleDownload = () => {
     const link = document.createElement("a");
     link.href = localStorage.getItem("tiffUrl")!;
-    link.download = `${projectName}.tiff`;
+    link.download = `${projectNameNormalized}.tiff`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -165,6 +166,12 @@ export default function Editor() {
     // Set local project name
     setProjectName(name);
 
+    let normalizedName = name
+    .replace(/\s+/g, '_') // Replace spaces with underscores
+    .replace(/[\\/]/g, '-') // Replace slashes with dashes
+    .replace(/[^a-zA-Z0-9-_]/g, ''); // Remove all characters that are not A-Z, a-z, 0-9, -, or _
+    setProjectNameNormalized(normalizedName);
+
     // If timer is running, reset it
     if (projectNameTimer.current) {
       clearTimeout(projectNameTimer.current);
@@ -172,8 +179,8 @@ export default function Editor() {
 
     // Set a 3 sec timer before sending API request to update name
     projectNameTimer.current = setTimeout(() => {
-      console.log("Updating project name:", name);
-      api.updateProjectName(projectId, name);
+      console.log("Updating project name:", name, "=>", projectNameNormalized);
+      api.updateProjectName(projectId, projectNameNormalized);
     }, 3000);
   }
 

--- a/frontend/components/component/editor.tsx
+++ b/frontend/components/component/editor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useRef, useState, useEffect } from "react";
 import SplitView from "./split-view";
 import CropImage from "./CropImage";
 import * as api from "./projectAPI";
@@ -12,12 +12,14 @@ export type ViewPage = 'sideBySide' | 'overlay' | 'crop'; // Pages in the editor
 export default function Editor() {
   const [projectId, setProjectId] = useState(0);
   const [projectName, setProjectName] = useState("Project 1");
+  const [projectNameMaxLength, setProjectNameMaxLength] = useState(32); // Max 32 characters for project name
   const [isAutoSaved, setIsAutoSaved] = useState(false);
   const [imageSrc, setImageSrc] = useState(localStorage.getItem("pdfData")!); // Keeps track of image URL
   const [activePage, setActivePage] = useState<ViewPage>('sideBySide');
   const [lastActivePage, setLastActivePage] = useState<ViewPage>('sideBySide');
   const [isGeorefValid, setIsGeorefValid] = useState(false);
   const [markerCount, setMarkerCount] = useState(0);
+  const projectNameTimer = useRef<NodeJS.Timeout | null>(null);
 
   // Array containing pairs of georeferenced markers and their corresponding image markers
   const [georefMarkerPairs, setGeorefMarkerPairs] = useState<
@@ -146,10 +148,33 @@ export default function Editor() {
   const handleDownload = () => {
     const link = document.createElement("a");
     link.href = localStorage.getItem("tiffUrl")!;
-    link.download = "georeferenced.tiff";
+    link.download = `${projectName}.tiff`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+  }
+
+  // Handle setting the project name
+  const handleSetProjectName = (name: string) => {
+    // Check if the project name is too long
+    if (name.length > projectNameMaxLength) {
+      console.log("Project name too long, truncating to", projectNameMaxLength);
+      name = name.slice(0, projectNameMaxLength);
+    }
+
+    // Set local project name
+    setProjectName(name);
+
+    // If timer is running, reset it
+    if (projectNameTimer.current) {
+      clearTimeout(projectNameTimer.current);
+    }
+
+    // Set a 3 sec timer before sending API request to update name
+    projectNameTimer.current = setTimeout(() => {
+      console.log("Updating project name:", name);
+      api.updateProjectName(projectId, name);
+    }, 3000);
   }
 
   return (
@@ -160,14 +185,15 @@ export default function Editor() {
         handleDownload={handleDownload}
         isAutoSaved={isAutoSaved}
         projectName={projectName}
+        projectNameMaxLength={projectNameMaxLength}
         projectId={projectId}
-        setProjectName={setProjectName}
+        setProjectName={handleSetProjectName}
         placedMarkerAmount={markerCount}
         hasBeenReferenced={isGeorefValid}
       />
 
       {activePage === 'sideBySide' ? (
-        console.log("Side by side view requested"),
+        //console.log("Side by side view requested"),
         <SplitView
           projectId={projectId}
           setGeorefMarkerPairs={setGeorefMarkerPairs}
@@ -179,12 +205,12 @@ export default function Editor() {
           onDeleteMarker={handleMarkerPairDelete}
         />
       ) : activePage === 'overlay' ? (
-        console.log("Overlay view requested"),
+        //console.log("Overlay view requested"),
         <OverlayView
           projectId={projectId}
         />
       ) : activePage === 'crop' ? (
-        console.log("Crop view requested"),
+        //console.log("Crop view requested"),
         <div className="flex flex-col items-center justify-center flex-1 bg-gray-400 dark:bg-gray-800">
           <div className="flex items-center justify-center w-full">
             <div className="w-1/2 flex justify-center items-center">

--- a/frontend/components/component/projectAPI.tsx
+++ b/frontend/components/component/projectAPI.tsx
@@ -109,6 +109,22 @@ export const initalGeorefimage = async (projectId: number): Promise<void> => {
 };
 
 /**
+ * PUT /project/{projectId} - { name }
+ * Updates the name of a project
+ * @param projectId - The ID of the project to update
+ * @param name - The new name of the project
+ */
+export const updateProjectName = async (projectId: number, name: string): Promise<void> => {
+  try {
+    await axios.put(`${BASE_URL}/project/${projectId}`, { name });
+  } catch (error) {
+    throw new Error(getErrorMessage(error as AxiosError<ErrorResponse>));
+  } finally {
+    console.log("Project name updated");
+  }
+}
+
+/**
  * DELETE /project/{projectId}
  * Deletes a project and its related data
  * @param projectId - The ID of the project to delete

--- a/frontend/components/ui/EditorToolbar.tsx
+++ b/frontend/components/ui/EditorToolbar.tsx
@@ -12,6 +12,7 @@ interface EditorToolbarProps {
     handleDownload: () => void;
     isAutoSaved: boolean;
     projectName: string;
+    projectNameMaxLength: number;
     projectId: number;
     setProjectName: (value: string) => void;
     hasBeenReferenced: boolean;
@@ -69,6 +70,7 @@ const EditorToolbar = (props: EditorToolbarProps) => {
                     onChange={(e) => props.setProjectName(e.target.value)}
                     className="text-xl font-semibold bg-transparent border-none outline-none"
                     placeholder="Project name" // Add placeholder attribute
+                    maxLength={props.projectNameMaxLength}
                 />
                 {props.isAutoSaved && (
                     <span className="text-sm text-gray-500">Auto saved</span>


### PR DESCRIPTION
This PR updates the way project names are handled, and are now updated in the backend. In addition, ground control points (should) have been added to the georeferenced file.

**Backend**:
georefHelper:
- Updated georeferenced file generation to include GCPs

**Frontend**:
editor:
- Added a projectNameMaxLength variable to ensure names aren't overly long
- Downloaded files are now named after project
- On project name update, a timer is set. If the name hasn't been modified in 3 sec, an API call is made to update it in the backend.
- Commented out some annoying console.logs

projectAPI:
- Added function updateProjectName. Takes project Id and a name. Self explanatory.

EditorToolbar:
- Updated name input to use maxLength defined in Editor