### PR TITLE
Final merge fix for tilingservice fix

### DIFF
--- a/backend/img2mapAPI/routers/converters.py
+++ b/backend/img2mapAPI/routers/converters.py
@@ -1,3 +1,11 @@
+""" This module contains the API router with endpoints for file conversion. 
+
+The module contains the following endpoints:
+    - Convert a .pdf file to a .png file
+    - Convert an image to a .png file
+    - Crop a .png file
+"""
+
 from fastapi import APIRouter, BackgroundTasks, File, UploadFile, HTTPException, Query
 from fastapi.responses import FileResponse
 #internal imports

--- a/backend/img2mapAPI/routers/georefProject.py
+++ b/backend/img2mapAPI/routers/georefProject.py
@@ -177,11 +177,11 @@ async def getGeorefImage(projectId: int):
 
    
 @router.get("/{projectId}/georef/coordinates")
-async def getCornerCoordinates(projectId: int):
-    """ Get the corner coordinates of the image of a project by id, returns the corner coordinates if found"""
+async def getImageCoordinates(projectId: int):
+    """ Get the image coordinates of the image of a project by id, returns the image coordinates if found in format [west, north, east, south]"""
     try:
-        cornerCoordinates = await _projectHandler.getCornerCoordinates(projectId)
-        return cornerCoordinates
+        imageCoordinates = await _projectHandler.getImageCoordinates(projectId)
+        return imageCoordinates
     except Exception as e:
         raise HTTPException(status_code=404, detail=str(e))
 

--- a/backend/img2mapAPI/routers/georefProject.py
+++ b/backend/img2mapAPI/routers/georefProject.py
@@ -1,3 +1,24 @@
+""" This module contains the API Router with endpoints for the georeferencing project
+
+The module contains the following endpoints:
+    - Create a project
+    - Update a project
+    - Delete a project
+    - Get a project
+    - Add a point to a project
+    - Update a point in a project
+    - Delete all points from a project
+    - Delete a point from a project
+    - Get all points of a project
+    - Get a point in a project by id
+    - Upload an image to a project
+    - Get the image of a project by id
+    - Georeference the image of a project by id
+    - Re-georeference the image of a project by id
+    - Get the georeferenced image of a project by id
+    - Get the corner coordinates of the image of a project by id
+"""
+
 from fastapi import APIRouter, File, UploadFile, HTTPException, BackgroundTasks, Path
 from fastapi.responses import FileResponse, Response
 from typing import List

--- a/backend/img2mapAPI/routers/server.py
+++ b/backend/img2mapAPI/routers/server.py
@@ -1,9 +1,13 @@
+"""  This module contains the API Router with endpoints for the server information
+
+The module contains the following endpoints:
+    - Get the server status
+"""
+
 from fastapi import APIRouter
 
-#API router for the server
 router = APIRouter()
 
-#default status of the server
 status = "running"
 
 @router.get('/')

--- a/backend/img2mapAPI/utils/core/georefHelper.py
+++ b/backend/img2mapAPI/utils/core/georefHelper.py
@@ -19,7 +19,17 @@ warnings.filterwarnings("ignore", category=rio.errors.NotGeoreferencedWarning) #
 defaultCrs = 'EPSG:4326'
 
 def createGcps(PointList : PointList):
-    """Create Rasterio GCPs from a list of points"""
+    """Create a list of GCPs from a list of points
+
+    Args:
+        PointList (PointList): The list of points to create the GCPs from.
+
+    Raises:
+        Exception: With message regarding the error.
+
+    Returns:
+        []: A list of rasterio GCPs.
+    """
     if len(PointList.points) < 3:
         raise Exception("Not enough points to create a transform")
 
@@ -174,6 +184,20 @@ def getCornerCoordinates(tiff_path):
 
 
 async def generateTile(tiff_path, x: int, y: int, z: int):
+    """Generate a tile from a georeferenced TIFF file.
+
+    Args:
+        tiff_path (string): Path to the georeferenced TIFF file.
+        x (int): column index of the tile.
+        y (int): row index of the tile.
+        z (int): Zoom level.
+
+    Raises:
+        e: Any exception that occurs during tile generation, that is not caught. unintended exceptions.
+
+    Returns:
+        Response: A FastAPI Response object containing the tile image. If the tile is outside the bounds of the image, a blank tile is returned.
+    """
     blanke_tile = Image.new('RGBA', (256, 256), (255, 255, 255, 0))
     bytes_io = io.BytesIO()
     blanke_tile.save(bytes_io, format='PNG')

--- a/backend/img2mapAPI/utils/core/georefHelper.py
+++ b/backend/img2mapAPI/utils/core/georefHelper.py
@@ -105,7 +105,9 @@ def InitialGeoreferencePngImage(tempFilePath, points: PointList, crs: str = defa
     transform = from_gcps(gcps) #create the transform
     dataset.transform = transform #set the transform
     dataset.crs = CRS.from_string(crs) #set the crs
-    dataset.gcps = (gcps, crs) #set the gcps
+
+    #TODO: dataset.gcps this breaks getting the bounds of the image
+    # dataset.gcps = (gcps, crs) #set the gcps 
 
     #define overview levels
     #is needed for generating the map tiles

--- a/backend/img2mapAPI/utils/core/georefHelper.py
+++ b/backend/img2mapAPI/utils/core/georefHelper.py
@@ -173,13 +173,13 @@ def getCornerCoordinates(tiff_path):
         # Get the bounds of the image
         bounds = dataset.bounds
 
-        # Calculate corner coordinates based on the bounds
-        top_left = (bounds.left, bounds.top)
-        top_right = (bounds.right, bounds.top)
-        bottom_right = (bounds.right, bounds.bottom)
-        bottom_left = (bounds.left, bounds.bottom)
+        # get west, south, east, north coordinates
+        west = bounds.left
+        south = bounds.bottom
+        east = bounds.right
+        north = bounds.top
 
-        return [top_left, top_right, bottom_right, bottom_left]
+        return [west, north, east, south]
 
 
 

--- a/backend/img2mapAPI/utils/core/georefHelper.py
+++ b/backend/img2mapAPI/utils/core/georefHelper.py
@@ -159,15 +159,15 @@ def reGeoreferencedImageTiff(innFilePath, points: PointList, crs: str = defaultC
 
     return filename
 
-def getCornerCoordinates(tiff_path):
+def getImageCoordinates(tiff_path):
     """
-    Get the corner coordinates (longitude, latitude) of a georeferenced TIFF.
+    Get the Image coordinates (longitude, latitude) of a georeferenced TIFF.
 
     Parameters:
     - tiff_path: Path to the georeferenced TIFF file.
 
     Returns:
-    - A list of corner coordinates in the order: [top left, top right, bottom right, bottom left].
+    - A list of corner coordinates in the order: [west, north, east south].
     """
     with rio.open(tiff_path) as dataset:
         # Get the bounds of the image

--- a/backend/img2mapAPI/utils/projectHandler.py
+++ b/backend/img2mapAPI/utils/projectHandler.py
@@ -514,15 +514,15 @@ class ProjectHandler:
         project.georeferencedFilePath = filePath
         await self.updateProject(project.id, project)
 
-    async def getCornerCoordinates(self, projectId: int):
+    async def getImageCoordinates(self, projectId: int):
         """
-        Get the corner coordinates of the image of a project
+        Get the image coordinates of the image of a project
         """
         #get the image file path
         project = await self.getProject(projectId)
         imageFilePath = project.georeferencedFilePath
         #get the corner coordinates
-        coordinates = georef.getCornerCoordinates(imageFilePath)
+        coordinates = georef.getImageCoordinates(imageFilePath)
         if coordinates is None:
             raise Exception("Coordinates not found")
         return coordinates

--- a/backend/img2mapAPI/utils/storage/data/sqliteLocalStorage.py
+++ b/backend/img2mapAPI/utils/storage/data/sqliteLocalStorage.py
@@ -155,7 +155,6 @@ class SQLiteStorage(sh):
                 query = f"SELECT * FROM {type} WHERE id = {id}"
                 cursor.execute(query, ())
                 row = cursor.fetchone()
-                print(row)
                 if row is not None:
                     ret = self.convertSequenseToDict(row, type)
                     return ret

--- a/backend/img2mapAPI/utils/storage/data/sqliteLocalStorage.py
+++ b/backend/img2mapAPI/utils/storage/data/sqliteLocalStorage.py
@@ -1,6 +1,4 @@
 import sqlite3 as sql
-import os
-import sys
 from typing import Union
 from pydantic import BaseModel
 from img2mapAPI.utils.storage.data.storageHandler import StorageHandler as sh

--- a/frontend/components/component/editor.tsx
+++ b/frontend/components/component/editor.tsx
@@ -10,7 +10,8 @@ export type ViewPage = "sideBySide" | "overlay" | "crop"; // Pages in the editor
 export default function Editor() {
   const [projectId, setProjectId] = useState(0);
   const [projectName, setProjectName] = useState("Project 1");
-  const [projectNameNormalized, setProjectNameNormalized] = useState("Project_1");
+  const [projectNameNormalized, setProjectNameNormalized] =
+    useState("Project_1");
   const [projectNameMaxLength, setProjectNameMaxLength] = useState(32); // Max 32 characters for project name
   const [isAutoSaved, setIsAutoSaved] = useState(false);
   const [imageSrc, setImageSrc] = useState(localStorage.getItem("pdfData")!); // Keeps track of image URL
@@ -179,9 +180,9 @@ export default function Editor() {
     setProjectName(name);
 
     let normalizedName = name
-    .replace(/\s+/g, '_') // Replace spaces with underscores
-    .replace(/[\\/]/g, '-') // Replace slashes with dashes
-    .replace(/[^a-zA-Z0-9-_]/g, ''); // Remove all characters that are not A-Z, a-z, 0-9, -, or _
+      .replace(/\s+/g, "_") // Replace spaces with underscores
+      .replace(/[\\/]/g, "-") // Replace slashes with dashes
+      .replace(/[^a-zA-Z0-9-_]/g, ""); // Remove all characters that are not A-Z, a-z, 0-9, -, or _
     setProjectNameNormalized(normalizedName);
 
     // If timer is running, reset it
@@ -194,7 +195,7 @@ export default function Editor() {
       console.log("Updating project name:", name, "=>", projectNameNormalized);
       api.updateProjectName(projectId, projectNameNormalized);
     }, 3000);
-  }
+  };
 
   return (
     <div className="flex flex-col h-screen bg-white">

--- a/frontend/components/component/editor.tsx
+++ b/frontend/components/component/editor.tsx
@@ -16,7 +16,7 @@ export default function Editor() {
   const [lastActivePage, setLastActivePage] = useState<ViewPage>("sideBySide");
   const [isGeorefValid, setIsGeorefValid] = useState(false);
   const [markerCount, setMarkerCount] = useState(0);
-  const [georefCornerCoordinates, setGeorefCornerCoordinates] = useState<
+  const [georefImageCoordinates, setGeorefImageCoordinates] = useState<
     [number, number, number, number]
   >([0, 0, 0, 0]);
 
@@ -190,7 +190,7 @@ export default function Editor() {
               imageMarkers={imageMarkers}
               setImageMarkers={setImageMarkers}
               onDeleteMarker={handleMarkerPairDelete}
-              setGeorefCornerCoordinates={setGeorefCornerCoordinates}
+              setGeorefImageCoordinates={setGeorefImageCoordinates}
             />
           ))
         : activePage === "overlay"
@@ -198,7 +198,7 @@ export default function Editor() {
           (
             <OverlayView
               projectId={projectId}
-              georefCornerCoordinates={georefCornerCoordinates}
+              georefImageCoordinates={georefImageCoordinates}
             />
           ))
         : activePage === "crop"
@@ -230,7 +230,7 @@ export default function Editor() {
               imageMarkers={imageMarkers}
               setImageMarkers={setImageMarkers}
               onDeleteMarker={handleMarkerPairDelete}
-              setGeorefCornerCoordinates={setGeorefCornerCoordinates}
+              setGeorefImageCoordinates={setGeorefImageCoordinates}
             />
           ))}
     </div>

--- a/frontend/components/component/editor.tsx
+++ b/frontend/components/component/editor.tsx
@@ -4,20 +4,21 @@ import CropImage from "./CropImage";
 import * as api from "./projectAPI";
 import OverlayView from "./overlayview";
 import EditorToolbar from "@/components/ui/EditorToolbar";
-import { Split } from "lucide-react";
-import { set } from "lodash";
 
-export type ViewPage = 'sideBySide' | 'overlay' | 'crop'; // Pages in the editor, add more pages as needed
+export type ViewPage = "sideBySide" | "overlay" | "crop"; // Pages in the editor, add more pages as needed
 
 export default function Editor() {
   const [projectId, setProjectId] = useState(0);
   const [projectName, setProjectName] = useState("Project 1");
   const [isAutoSaved, setIsAutoSaved] = useState(false);
   const [imageSrc, setImageSrc] = useState(localStorage.getItem("pdfData")!); // Keeps track of image URL
-  const [activePage, setActivePage] = useState<ViewPage>('sideBySide');
-  const [lastActivePage, setLastActivePage] = useState<ViewPage>('sideBySide');
+  const [activePage, setActivePage] = useState<ViewPage>("sideBySide");
+  const [lastActivePage, setLastActivePage] = useState<ViewPage>("sideBySide");
   const [isGeorefValid, setIsGeorefValid] = useState(false);
   const [markerCount, setMarkerCount] = useState(0);
+  const [georefCornerCoordinates, setGeorefCornerCoordinates] = useState<
+    [number, number, number, number]
+  >([0, 0, 0, 0]);
 
   // Array containing pairs of georeferenced markers and their corresponding image markers
   const [georefMarkerPairs, setGeorefMarkerPairs] = useState<
@@ -95,7 +96,7 @@ export default function Editor() {
     // If the user clicks on a different page, set the current page, and set new active page
     setLastActivePage(activePage); // Save the last active page
     setActivePage(page); // Set the active page in the toolbar
-  }
+  };
 
   // Update the image source when the user has cropped the image, and close the crop tool
   const handleCrop = () => {
@@ -106,14 +107,19 @@ export default function Editor() {
     // Reset the image source to the original image and go back to old view
     setImageSrc(localStorage.getItem("pdfData")!);
     setViewPage(lastActivePage);
-  }
-  
+  };
+
   // Check if there are atleast 3 markers to display the coordinates table and the values are not 0, and set the state
   useEffect(() => {
-    const valid = georefMarkerPairs.length >= 3 && 
-      georefMarkerPairs.every((pair) => pair.latLong.every((val) => val !== 0)) && 
-      georefMarkerPairs.every((pair) => pair.pixelCoords.every((val) => val !== 0));
-  
+    const valid =
+      georefMarkerPairs.length >= 3 &&
+      georefMarkerPairs.every((pair) =>
+        pair.latLong.every((val) => val !== 0)
+      ) &&
+      georefMarkerPairs.every((pair) =>
+        pair.pixelCoords.every((val) => val !== 0)
+      );
+
     setIsGeorefValid(valid);
   }, [georefMarkerPairs]);
 
@@ -134,7 +140,7 @@ export default function Editor() {
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-  }
+  };
 
   return (
     <div className="flex flex-col h-screen bg-white">
@@ -150,50 +156,59 @@ export default function Editor() {
         hasBeenReferenced={isGeorefValid}
       />
 
-      {activePage === 'sideBySide' ? (
-        console.log("Side by side view requested"),
-        <SplitView
-          projectId={projectId}
-          setGeorefMarkerPairs={setGeorefMarkerPairs}
-          georefMarkerPairs={georefMarkerPairs}
-          mapMarkers={mapMarkers}
-          setMapMarkers={setMapMarkers}
-          imageMarkers={imageMarkers}
-          setImageMarkers={setImageMarkers}
-        />
-      ) : activePage === 'overlay' ? (
-        console.log("Overlay view requested"),
-        <OverlayView
-          projectId={projectId}
-        />
-      ) : activePage === 'crop' ? (
-        console.log("Crop view requested"),
-        <div className="flex flex-col items-center justify-center flex-1 bg-gray-400 dark:bg-gray-800">
-          <div className="flex items-center justify-center w-full">
-            <div className="w-1/2 flex justify-center items-center">
-              <CropImage
-                onCrop={handleCrop}
-                onCancelCrop={cancelCrop}
-                resetMarkerRequest={resetMarkerRequest}
-                projectId={projectId}
-                placedMarkerAmount={markerCount}
-              />
+      {activePage === "sideBySide"
+        ? (console.log("Side by side view requested"),
+          (
+            <SplitView
+              projectId={projectId}
+              setGeorefMarkerPairs={setGeorefMarkerPairs}
+              georefMarkerPairs={georefMarkerPairs}
+              mapMarkers={mapMarkers}
+              setMapMarkers={setMapMarkers}
+              imageMarkers={imageMarkers}
+              setImageMarkers={setImageMarkers}
+              setGeorefCornerCoordinates={setGeorefCornerCoordinates}
+            />
+          ))
+        : activePage === "overlay"
+        ? (console.log("Overlay view requested"),
+          (
+            <OverlayView
+              projectId={projectId}
+              georefCornerCoordinates={georefCornerCoordinates}
+            />
+          ))
+        : activePage === "crop"
+        ? (console.log("Crop view requested"),
+          (
+            <div className="flex flex-col items-center justify-center flex-1 bg-gray-400 dark:bg-gray-800">
+              <div className="flex items-center justify-center w-full">
+                <div className="w-1/2 flex justify-center items-center">
+                  <CropImage
+                    onCrop={handleCrop}
+                    onCancelCrop={cancelCrop}
+                    resetMarkerRequest={resetMarkerRequest}
+                    projectId={projectId}
+                    placedMarkerAmount={markerCount}
+                  />
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      ) : (
-        // Just in case something goes wrong, display the SplitView as a fallback
-        console.log("Error, displaying fallback view"),
-        <SplitView
-          projectId={projectId}
-          setGeorefMarkerPairs={setGeorefMarkerPairs}
-          georefMarkerPairs={georefMarkerPairs}
-          mapMarkers={mapMarkers}
-          setMapMarkers={setMapMarkers}
-          imageMarkers={imageMarkers}
-          setImageMarkers={setImageMarkers}
-        />
-      )}
+          ))
+        : // Just in case something goes wrong, display the SplitView as a fallback
+          (console.log("Error, displaying fallback view"),
+          (
+            <SplitView
+              projectId={projectId}
+              setGeorefMarkerPairs={setGeorefMarkerPairs}
+              georefMarkerPairs={georefMarkerPairs}
+              mapMarkers={mapMarkers}
+              setMapMarkers={setMapMarkers}
+              imageMarkers={imageMarkers}
+              setImageMarkers={setImageMarkers}
+              setGeorefCornerCoordinates={setGeorefCornerCoordinates}
+            />
+          ))}
     </div>
   );
 }

--- a/frontend/components/component/editor.tsx
+++ b/frontend/components/component/editor.tsx
@@ -22,7 +22,11 @@ export default function Editor() {
 
   // Array containing pairs of georeferenced markers and their corresponding image markers
   const [georefMarkerPairs, setGeorefMarkerPairs] = useState<
-    { pointId: number | null ; latLong: [number, number]; pixelCoords: [number, number] }[]
+    {
+      pointId: number | null;
+      latLong: [number, number];
+      pixelCoords: [number, number];
+    }[]
   >([]);
   const [mapMarkers, setMapMarkers] = useState<
     { geoCoordinates: [number, number] }[]
@@ -135,17 +139,19 @@ export default function Editor() {
 
   function handleMarkerPairDelete(pointId: number | null, index: number): void {
     // Delete the marker pair locally
-    console.log("Deleting marker pair at index", index+1);
-    setGeorefMarkerPairs(prevState => prevState.filter((_, i) => i !== index));
-    setMapMarkers(prevState => prevState.filter((_, i) => i !== index));
-    setImageMarkers(prevState => prevState.filter((_, i) => i !== index));
+    console.log("Deleting marker pair at index", index + 1);
+    setGeorefMarkerPairs((prevState) =>
+      prevState.filter((_, i) => i !== index)
+    );
+    setMapMarkers((prevState) => prevState.filter((_, i) => i !== index));
+    setImageMarkers((prevState) => prevState.filter((_, i) => i !== index));
     console.log(imageMarkers, mapMarkers, georefMarkerPairs);
 
     // Return if no pointId is given, else proceed with API deletion
     if (pointId === null) {
       return;
     }
-    api.deleteMarkerPair(projectId, pointId)
+    api.deleteMarkerPair(projectId, pointId);
   }
 
   // Handle download requests
@@ -172,54 +178,61 @@ export default function Editor() {
         hasBeenReferenced={isGeorefValid}
       />
 
-      {activePage === 'sideBySide' ? (
-        console.log("Side by side view requested"),
-        <SplitView
-          projectId={projectId}
-          setGeorefMarkerPairs={setGeorefMarkerPairs}
-          georefMarkerPairs={georefMarkerPairs}
-          mapMarkers={mapMarkers}
-          setMapMarkers={setMapMarkers}
-          imageMarkers={imageMarkers}
-          setImageMarkers={setImageMarkers}
-          onDeleteMarker={handleMarkerPairDelete}
-          setGeorefCornerCoordinates={setGeorefCornerCoordinates}
-        />
-      ) : activePage === 'overlay' ? (
-        console.log("Overlay view requested"),
-        <OverlayView
-          projectId={projectId}
-        />
-      ) : activePage === 'crop' ? (
-        console.log("Crop view requested"),
-        <div className="flex flex-col items-center justify-center flex-1 bg-gray-400 dark:bg-gray-800">
-          <div className="flex items-center justify-center w-full">
-            <div className="w-1/2 flex justify-center items-center">
-              <CropImage
-                onCrop={handleCrop}
-                onCancelCrop={cancelCrop}
-                resetMarkerRequest={resetMarkerRequest}
-                projectId={projectId}
-                placedMarkerAmount={markerCount}
-              />
+      {activePage === "sideBySide"
+        ? (console.log("Side by side view requested"),
+          (
+            <SplitView
+              projectId={projectId}
+              setGeorefMarkerPairs={setGeorefMarkerPairs}
+              georefMarkerPairs={georefMarkerPairs}
+              mapMarkers={mapMarkers}
+              setMapMarkers={setMapMarkers}
+              imageMarkers={imageMarkers}
+              setImageMarkers={setImageMarkers}
+              onDeleteMarker={handleMarkerPairDelete}
+              setGeorefCornerCoordinates={setGeorefCornerCoordinates}
+            />
+          ))
+        : activePage === "overlay"
+        ? (console.log("Overlay view requested"),
+          (
+            <OverlayView
+              projectId={projectId}
+              georefCornerCoordinates={georefCornerCoordinates}
+            />
+          ))
+        : activePage === "crop"
+        ? (console.log("Crop view requested"),
+          (
+            <div className="flex flex-col items-center justify-center flex-1 bg-gray-400 dark:bg-gray-800">
+              <div className="flex items-center justify-center w-full">
+                <div className="w-1/2 flex justify-center items-center">
+                  <CropImage
+                    onCrop={handleCrop}
+                    onCancelCrop={cancelCrop}
+                    resetMarkerRequest={resetMarkerRequest}
+                    projectId={projectId}
+                    placedMarkerAmount={markerCount}
+                  />
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      ) : (
-        // Just in case something goes wrong, display the SplitView as a fallback
-        console.log("Error, displaying fallback view"),
-        <SplitView
-          projectId={projectId}
-          setGeorefMarkerPairs={setGeorefMarkerPairs}
-          georefMarkerPairs={georefMarkerPairs}
-          mapMarkers={mapMarkers}
-          setMapMarkers={setMapMarkers}
-          imageMarkers={imageMarkers}
-          setImageMarkers={setImageMarkers}
-          onDeleteMarker={handleMarkerPairDelete}
-          setGeorefCornerCoordinates={setGeorefCornerCoordinates}
-        />
-      )}
+          ))
+        : // Just in case something goes wrong, display the SplitView as a fallback
+          (console.log("Error, displaying fallback view"),
+          (
+            <SplitView
+              projectId={projectId}
+              setGeorefMarkerPairs={setGeorefMarkerPairs}
+              georefMarkerPairs={georefMarkerPairs}
+              mapMarkers={mapMarkers}
+              setMapMarkers={setMapMarkers}
+              imageMarkers={imageMarkers}
+              setImageMarkers={setImageMarkers}
+              onDeleteMarker={handleMarkerPairDelete}
+              setGeorefCornerCoordinates={setGeorefCornerCoordinates}
+            />
+          ))}
     </div>
   );
 }

--- a/frontend/components/component/overlayview.tsx
+++ b/frontend/components/component/overlayview.tsx
@@ -9,14 +9,14 @@ import { RotateLoader } from "react-spinners";
 
 interface MapOverlayProps {
   projectId: number;
-  georefCornerCoordinates: [number, number, number, number];
+  georefImageCoordinates: [number, number, number, number];
 }
 
 const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN || "";
 
 const OverlayView = ({
   projectId,
-  georefCornerCoordinates,
+  georefImageCoordinates,
 }: MapOverlayProps) => {
   const [dataUrl, setDataUrl] = useState("");
   const [imageSrc, setImageSrc] = useState(localStorage.getItem("pdfData")!);
@@ -27,15 +27,13 @@ const OverlayView = ({
 
   //Used for setting the initial viewstate of the image
   // sets latitude and longitude based on the center geo coordinates of the image
-  const latitude =
-    (georefCornerCoordinates[1] + georefCornerCoordinates[3]) / 2;
-  const longitude =
-    (georefCornerCoordinates[0] + georefCornerCoordinates[2]) / 2;
+  const latitude = (georefImageCoordinates[1] + georefImageCoordinates[3]) / 2;
+  const longitude = (georefImageCoordinates[0] + georefImageCoordinates[2]) / 2;
 
   //zoom based on geo-graphical width of the image where geocornercoordinates is [west, south, east, north]
   const zoom = Math.floor(
     Math.log2(
-      360 / Math.abs(georefCornerCoordinates[2] - georefCornerCoordinates[0])
+      360 / Math.abs(georefImageCoordinates[2] - georefImageCoordinates[0])
     )
   );
 
@@ -80,8 +78,8 @@ const OverlayView = ({
       );
   }, [projectId, imageSrc]);
 
-  // if georefcornercoordinates is not set, show loading spinner
-  if (!georefCornerCoordinates) {
+  // if georefImageCoordinates is not set, show loading spinner
+  if (!georefImageCoordinates) {
     return (
       <div className="flex w-full h-full flex-col">
         <div className="flex h-full justify-center items-center">

--- a/frontend/components/component/projectAPI.tsx
+++ b/frontend/components/component/projectAPI.tsx
@@ -160,23 +160,46 @@ export const deleteAllMarkers = async (projectId: number): Promise<void> => {
  * @returns {Promise<void>} A Promise that resolves when the image is cropped successfully.
  * @throws {Error} Will throw an error if the request fails.
  */
-export const cropImage = async (formData: FormData, p1x: number, p1y: number, p2x: number, p2y: number): Promise<string> => {
+export const cropImage = async (
+  formData: FormData,
+  p1x: number,
+  p1y: number,
+  p2x: number,
+  p2y: number
+): Promise<string> => {
   try {
-    const response = await axios.post(`${BASE_URL}/converter/cropPng?p1x=${p1x}&p1y=${p1y}&p2x=${p2x}&p2y=${p2y}`, formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data'
-      },
-      responseType: 'blob'
-    });
+    const response = await axios.post(
+      `${BASE_URL}/converter/cropPng?p1x=${p1x}&p1y=${p1y}&p2x=${p2x}&p2y=${p2y}`,
+      formData,
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+        responseType: "blob",
+      }
+    );
 
     // Convert the response data to a Blob, create a Blob URL and return the URL
-    const newBlob = new Blob([response.data], { type: 'image/png' });
+    const newBlob = new Blob([response.data], { type: "image/png" });
     const blobUrl = URL.createObjectURL(newBlob);
     return blobUrl;
-
   } catch (error) {
     throw new Error(getErrorMessage(error as AxiosError<ErrorResponse>));
   } finally {
     console.log("Image cropped");
+  }
+};
+
+//get from "{base_url}/project/{projectid}/georef/coordinates" which returns [top_left, top_right, bottom_right, bottom_left]
+export const getGeorefCoordinates = async (
+  projectId: number
+): Promise<number[][]> => {
+  try {
+    const response = await axios.get(
+      `${BASE_URL}/project/${projectId}/georef/coordinates`
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error(getErrorMessage(error as AxiosError<ErrorResponse>));
   }
 };

--- a/frontend/components/component/projectAPI.tsx
+++ b/frontend/components/component/projectAPI.tsx
@@ -234,7 +234,7 @@ export const cropImage = async (
   }
 };
 
-//get from "{base_url}/project/{projectid}/georef/coordinates" which returns [top_left, top_right, bottom_right, bottom_left]
+//get from "{base_url}/project/{projectid}/georef/coordinates" which returns [west, north, east, south]
 export const getGeorefCoordinates = async (
   projectId: number
 ): Promise<number[][]> => {

--- a/frontend/components/component/projectAPI.tsx
+++ b/frontend/components/component/projectAPI.tsx
@@ -114,7 +114,10 @@ export const initalGeorefimage = async (projectId: number): Promise<void> => {
  * @param projectId - The ID of the project to update
  * @param name - The new name of the project
  */
-export const updateProjectName = async (projectId: number, name: string): Promise<void> => {
+export const updateProjectName = async (
+  projectId: number,
+  name: string
+): Promise<void> => {
   try {
     await axios.put(`${BASE_URL}/project/${projectId}`, { name });
   } catch (error) {
@@ -122,7 +125,7 @@ export const updateProjectName = async (projectId: number, name: string): Promis
   } finally {
     console.log("Project name updated");
   }
-}
+};
 
 /**
  * DELETE /project/{projectId}
@@ -172,7 +175,10 @@ export const deleteAllMarkers = async (projectId: number): Promise<void> => {
  * @param projectId - The ID of the project to delete the marker pair from
  * @param pointId - The ID of the marker pair to delete
  */
-export const deleteMarkerPair = async (projectId: number, pointId: number): Promise<void> => {
+export const deleteMarkerPair = async (
+  projectId: number,
+  pointId: number
+): Promise<void> => {
   try {
     await axios.delete(`${BASE_URL}/project/${projectId}/point/${pointId}`, {
       headers: {

--- a/frontend/components/component/split-view.tsx
+++ b/frontend/components/component/split-view.tsx
@@ -31,7 +31,11 @@ interface SplitViewProps {
   }[];
   setGeorefMarkerPairs: React.Dispatch<
     React.SetStateAction<
-      { pointId: number | null, latLong: [number, number]; pixelCoords: [number, number] }[]
+      {
+        pointId: number | null;
+        latLong: [number, number];
+        pixelCoords: [number, number];
+      }[]
     >
   >;
   mapMarkers: { geoCoordinates: [number, number] }[];
@@ -44,7 +48,7 @@ interface SplitViewProps {
     React.SetStateAction<{ pixelCoordinates: [number, number] }[]>
   >;
 
-  setGeorefCornerCoordinates: React.Dispatch<
+  setGeorefImageCoordinates: React.Dispatch<
     React.SetStateAction<[number, number, number, number]>
   >;
 
@@ -59,8 +63,8 @@ export default function SplitView({
   setMapMarkers,
   imageMarkers,
   setImageMarkers,
-  setGeorefCornerCoordinates,
-  onDeleteMarker
+  setGeorefImageCoordinates,
+  onDeleteMarker,
 }: SplitViewProps) {
   //project states
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -124,7 +128,10 @@ export default function SplitView({
           lastPair.pixelCoords[1] !== 0)
       ) {
         // Add a new pair if the array is empty or the last pair is complete
-        return [...pairs, { pointId: null, latLong: geoCoordinates, pixelCoords: [0, 0] }];
+        return [
+          ...pairs,
+          { pointId: null, latLong: geoCoordinates, pixelCoords: [0, 0] },
+        ];
       } else {
         // Update the last pair if it's incomplete
         return pairs.map((pair, index) =>
@@ -151,7 +158,10 @@ export default function SplitView({
           lastPair.latLong[1] !== 0)
       ) {
         // Add a new pair if the array is empty or the last pair is complete
-        return [...pairs, { pointId: null, latLong: [0, 0], pixelCoords: pixelCoordinates }];
+        return [
+          ...pairs,
+          { pointId: null, latLong: [0, 0], pixelCoords: pixelCoordinates },
+        ];
       } else {
         // Update the last pair if it's incomplete
         return pairs.map((pair, index) =>
@@ -171,7 +181,7 @@ export default function SplitView({
         index === pairs.length - 1 ? { ...pair, pointId } : pair
       )
     );
-  }
+  };
 
   //image states
   const [transform, setTransform] = useState({ x: 0, y: 0 });
@@ -321,7 +331,7 @@ export default function SplitView({
           console.log("Success:", data);
           //flatten 2d array to 1d array
           const flatData = data.flat();
-          setGeorefCornerCoordinates(
+          setGeorefImageCoordinates(
             flatData as [number, number, number, number]
           );
           console.log("Georef Corner Coordinates:", data);

--- a/frontend/components/component/split-view.tsx
+++ b/frontend/components/component/split-view.tsx
@@ -326,9 +326,8 @@ export default function SplitView({
     api
       .initalGeorefimage(projectId)
       .then((data) => {
-        console.log("Success:", data);
+        console.log("Success image georeferenced:", data);
         api.getGeorefCoordinates(projectId).then((data) => {
-          console.log("Success:", data);
           //flatten 2d array to 1d array
           const flatData = data.flat();
           setGeorefImageCoordinates(

--- a/frontend/components/component/split-view.tsx
+++ b/frontend/components/component/split-view.tsx
@@ -1,4 +1,4 @@
-import { use, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Map, NavigationControl, GeolocateControl, Marker } from "react-map-gl";
 import type { MapRef } from "react-map-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
@@ -42,6 +42,9 @@ interface SplitViewProps {
   setImageMarkers: React.Dispatch<
     React.SetStateAction<{ pixelCoordinates: [number, number] }[]>
   >;
+  setGeorefCornerCoordinates: React.Dispatch<
+    React.SetStateAction<[number, number, number, number]>
+  >;
 }
 
 export default function SplitView({
@@ -52,6 +55,7 @@ export default function SplitView({
   setMapMarkers,
   imageMarkers,
   setImageMarkers,
+  setGeorefCornerCoordinates,
 }: SplitViewProps) {
   //project states
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -296,6 +300,15 @@ export default function SplitView({
       .initalGeorefimage(projectId)
       .then((data) => {
         console.log("Success:", data);
+        api.getGeorefCoordinates(projectId).then((data) => {
+          console.log("Success:", data);
+          //flatten 2d array to 1d array
+          const flatData = data.flat();
+          setGeorefCornerCoordinates(
+            flatData as [number, number, number, number]
+          );
+          console.log("Georef Corner Coordinates:", data);
+        });
       })
       .catch((error) => {
         console.error("Error:", error.message);


### PR DESCRIPTION
# Changes

## Backend

**GeorefHelper**
initalGeoref
Commented out line which broke the fetching of image coordinates.

getImageCoordinates
Changed the output of the function to instead return west, north, east, south geocoordinates of the image instead of corner coordinates.

generateTile
Added comment to describe functions behavior and use.

**georefProject.py**
Renamed variable names, function names, and comment description to reflect new behavior.

**projectHandler.py**
Renamed ... as above

**sqliteLocalStorage.py**
removed unsused debug print

## Frontend

**editor.tsx**
Added georefImageCoordinates array to store the [west, north, east, south] coordinates of the georeferenced image.
Now passes setgeorefImageCoordinates to splitview component call.

**splitview.tsx**
Sets the georefImageCoordinates right after the image has been georeferenced.

**overlay.tsx**
Calculates the center latitude , longitude and zoom for mapbox based of the georeferenced coordinates and sets them to the mapbox inital viewstate. This fixes the issue of the tile serving crashing too by circumventing the use for navigating the map to find the georeferenced area.

**projectAPI,tsx**
calls the georefcoordinate route to get the images coordinates.

