### PR TITLE
Various frontend bugfixes and changes

### DIFF
--- a/frontend/app/Editor/page.tsx
+++ b/frontend/app/Editor/page.tsx
@@ -1,39 +1,10 @@
 'use client';
-import { useRouter } from 'next/navigation'
-import { useState, useEffect } from 'react';
 import Editor from '../../components/component/editor';
 
 export default function Page() {
-    const router = useRouter();
-    const [pdfData, setPdfData] = useState<string | null>(null);
-
-    useEffect(() => {
-        // If pdfData is not null, set the pdfData state variable to the value of the pdfData key in localStorage
-        if (typeof window !== 'undefined') {
-            const pdfDataFromLocalStorage = window.localStorage.getItem('pdfData');
-            setPdfData(pdfDataFromLocalStorage !== null ? pdfDataFromLocalStorage : null);
-
-            if (pdfDataFromLocalStorage) {
-                const image = new Image();
-
-                image.onerror = () => {
-                    // If the image cannot be loaded, redirect to the home page
-                    router.push('/');
-                };
-
-                // Set the src of the image to start loading it. 
-                //If the image is not found, the onerror event will be triggered, and the user will be redirected to the home page
-                image.src = pdfDataFromLocalStorage;
-            } else {
-                // If pdfData is null, redirect to the home page
-                router.push('/');
-            }
-        }
-    }, []);
-
     return (
         <main>
-            {pdfData !== null && <Editor />}
+            <Editor />
         </main>
     );
 }

--- a/frontend/components/component/editor.tsx
+++ b/frontend/components/component/editor.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useEffect } from "react";
+import { useRouter } from 'next/navigation'
 import SplitView from "./split-view";
 import CropImage from "./CropImage";
 import * as api from "./projectAPI";
@@ -8,6 +9,7 @@ import EditorToolbar from "@/components/ui/EditorToolbar";
 export type ViewPage = "sideBySide" | "overlay" | "crop"; // Pages in the editor, add more pages as needed
 
 export default function Editor() {
+  const router = useRouter();
   const [projectId, setProjectId] = useState(0);
   const [projectName, setProjectName] = useState("Project 1");
   const [projectNameNormalized, setProjectNameNormalized] =
@@ -46,6 +48,31 @@ export default function Editor() {
     setMarkerCount(mapMarkers.length + imageMarkers.length);
   }, [mapMarkers, imageMarkers]);
 
+  //call the addProject function when the component mounts
+  useEffect(() => {
+    // Check if the image source from local storage is valid, else redirect to home page
+    if (typeof window !== 'undefined') {
+      // If image source is null, redirect to home page
+      if (imageSrc === null) {
+          router.push('/');
+      }
+
+      // If image source is not null, create an image object to check if the image is valid
+      if (imageSrc !== null) {
+          const image = new Image();
+
+          image.onerror = () => {
+              router.push('/');
+          };
+
+          image.src = imageSrc;
+      }
+    }
+
+    // After image is loaded, add the project
+    addProject(projectName);
+  }, []);
+
   //function to add a new project
   const addProject = (name: string) => {
     //make API call to add project
@@ -83,11 +110,6 @@ export default function Editor() {
       console.error("Error uploading image:", error);
     }
   };
-
-  //call the addProject function when the component mounts
-  useEffect(() => {
-    addProject(projectName);
-  }, []);
 
   const handleSave = () => {
     setIsAutoSaved(true);

--- a/frontend/components/component/editor.tsx
+++ b/frontend/components/component/editor.tsx
@@ -32,6 +32,7 @@ export default function Editor() {
       pixelCoords: [number, number];
     }[]
   >([]);
+  
   const [mapMarkers, setMapMarkers] = useState<
     { geoCoordinates: [number, number] }[]
   >([]);
@@ -116,20 +117,6 @@ export default function Editor() {
     setImageSrc(localStorage.getItem("pdfData")!);
     setViewPage(lastActivePage);
   };
-
-  // Check if there are atleast 3 markers to display the coordinates table and the values are not 0, and set the state
-  useEffect(() => {
-    const valid =
-      georefMarkerPairs.length >= 3 &&
-      georefMarkerPairs.every((pair) =>
-        pair.latLong.every((val) => val !== 0)
-      ) &&
-      georefMarkerPairs.every((pair) =>
-        pair.pixelCoords.every((val) => val !== 0)
-      );
-
-    setIsGeorefValid(valid);
-  }, [georefMarkerPairs]);
 
   // Resets all marker arrays and disables overlay view
   const resetMarkerRequest = () => {
@@ -224,6 +211,7 @@ export default function Editor() {
               setImageMarkers={setImageMarkers}
               onDeleteMarker={handleMarkerPairDelete}
               setGeorefImageCoordinates={setGeorefImageCoordinates}
+              setHasBeenGeoreferenced={setIsGeorefValid}
             />
           ))
         : activePage === "overlay"
@@ -264,6 +252,7 @@ export default function Editor() {
               setImageMarkers={setImageMarkers}
               onDeleteMarker={handleMarkerPairDelete}
               setGeorefImageCoordinates={setGeorefImageCoordinates}
+              setHasBeenGeoreferenced={setIsGeorefValid}
             />
           ))}
     </div>

--- a/frontend/components/component/editor.tsx
+++ b/frontend/components/component/editor.tsx
@@ -32,7 +32,7 @@ export default function Editor() {
       pixelCoords: [number, number];
     }[]
   >([]);
-  
+
   const [mapMarkers, setMapMarkers] = useState<
     { geoCoordinates: [number, number] }[]
   >([]);
@@ -57,6 +57,7 @@ export default function Editor() {
         setProjectId(data.id);
         console.log("Project ID:", data.id);
         uploadImage(data.id);
+        console.log("Project added");
       })
       .catch((error) => {
         // handle error
@@ -86,7 +87,6 @@ export default function Editor() {
   //call the addProject function when the component mounts
   useEffect(() => {
     addProject(projectName);
-    console.log("Project added");
   }, []);
 
   const handleSave = () => {

--- a/frontend/components/component/projectAPI.tsx
+++ b/frontend/components/component/projectAPI.tsx
@@ -22,12 +22,12 @@ interface ErrorResponse {
 // Base URL for the backend API from .env
 const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
 
-let hasMadeProjectApiCall = false;
-
 // A helper function to extract error message
 function getErrorMessage(error: AxiosError<ErrorResponse>): string {
   return error.response?.data.detail || "Something went wrong!";
 }
+
+let hasMadeProjectApiCall = false;
 
 export const addProject = async (name: string): Promise<ProjectResponse> => {
   if (hasMadeProjectApiCall) return Promise.reject("API call already made");
@@ -37,6 +37,7 @@ export const addProject = async (name: string): Promise<ProjectResponse> => {
       `${BASE_URL}/project/`,
       { name }
     );
+    hasMadeProjectApiCall = false;
     return response.data;
   } catch (error) {
     throw new Error(getErrorMessage(error as AxiosError<ErrorResponse>));

--- a/frontend/components/component/split-view.tsx
+++ b/frontend/components/component/split-view.tsx
@@ -53,6 +53,8 @@ interface SplitViewProps {
   >;
 
   onDeleteMarker: (pointId: number | null, index: number) => void;
+
+  setHasBeenGeoreferenced: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function SplitView({
@@ -65,6 +67,7 @@ export default function SplitView({
   setImageMarkers,
   setGeorefImageCoordinates,
   onDeleteMarker,
+  setHasBeenGeoreferenced,
 }: SplitViewProps) {
   //project states
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -327,6 +330,7 @@ export default function SplitView({
       .initalGeorefimage(projectId)
       .then((data) => {
         console.log("Success image georeferenced:", data);
+        setHasBeenGeoreferenced(true);
         api.getGeorefCoordinates(projectId).then((data) => {
           //flatten 2d array to 1d array
           const flatData = data.flat();

--- a/frontend/components/component/split-view.tsx
+++ b/frontend/components/component/split-view.tsx
@@ -330,7 +330,6 @@ export default function SplitView({
       .initalGeorefimage(projectId)
       .then((data) => {
         console.log("Success image georeferenced:", data);
-        setHasBeenGeoreferenced(true);
         api.getGeorefCoordinates(projectId).then((data) => {
           //flatten 2d array to 1d array
           const flatData = data.flat();
@@ -338,6 +337,7 @@ export default function SplitView({
             flatData as [number, number, number, number]
           );
           console.log("Georef Corner Coordinates:", data);
+          setHasBeenGeoreferenced(true);
         });
       })
       .catch((error) => {

--- a/frontend/components/ui/EditorToolbar.tsx
+++ b/frontend/components/ui/EditorToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from "@/components/ui/button";
 import FormModal from "@/components/ui/FormModal";
 import WarningExitModal from '@/components/ui/WarningExitModal';
@@ -32,6 +32,21 @@ const EditorToolbar = (props: EditorToolbarProps) => {
     const handleFeedbackClick = () => {
         setFormModalOpen(true);
     };
+
+    // Warning popup when closing browser/tab
+    useEffect(() => {
+        const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+          event.preventDefault();
+          event.returnValue = ''; // Supposedly chrome requires returnvalue to be set
+        };
+      
+        window.addEventListener('beforeunload', handleBeforeUnload);
+      
+        // Cleanup when component unmounts
+        return () => {
+          window.removeEventListener('beforeunload', handleBeforeUnload);
+        };
+    }, []);
 
     // When the user clicks the Exit Editor button
     const handleExitEditor = () => {


### PR DESCRIPTION
This PR includes various bugfixes and changes in the frontend, such as:

**Editor (page, not component):**
- Removed image source check from this page (is moved to component)

**Editor (component):**
- Moved image source component here, is done when component mounts. Redirects if image source is not valid/empty. Fixes a bug where a user would be stuck in an Editor limbo state.
- Removed old "valid check" for georef. Is now instead told by split-view that georef is valid when the georeffed image and its georef coordinates are completed. Fixes a bug where the user would be placed somewhere in Africa and potentially crashing the backend.

**projectAPI:**
- Added a variable reset. Fixes a bug where new projects would not be added after a refresh, leaving the Editor in a limbo state.

**split-view:**
- Added a setHasBeenGeoreferenced-prop. Used for enabling Overlay and Download buttons.

**EditorToolbar:**
- Added a warning popup when closing the browser/tab (The classic "Changes you made may not be saved")