### PR TITLE
Build error window fix

### DIFF
--- a/frontend/app/Editor/page.tsx
+++ b/frontend/app/Editor/page.tsx
@@ -10,7 +10,7 @@ export default function Page() {
     }
     return (
         <main>
-            <Editor />
+            {typeof window !== 'undefined' ? <Editor /> : null} 
         </main>
     );
 }

--- a/frontend/app/Editor/page.tsx
+++ b/frontend/app/Editor/page.tsx
@@ -1,7 +1,13 @@
 'use client';
 import Editor from '../../components/component/editor';
+import { useRouter } from 'next/navigation';
 
 export default function Page() {
+    const router = useRouter();
+    // check window object to see if we are in the browser or not then redirect to the home page
+    if (typeof window == 'undefined') {
+        router.push('/');
+    }
     return (
         <main>
             <Editor />

--- a/frontend/components/component/editor.tsx
+++ b/frontend/components/component/editor.tsx
@@ -16,7 +16,7 @@ export default function Editor() {
     useState("Project_1");
   const [projectNameMaxLength, setProjectNameMaxLength] = useState(32); // Max 32 characters for project name
   const [isAutoSaved, setIsAutoSaved] = useState(false);
-  const [imageSrc, setImageSrc] = useState(""); // Keeps track of image URL
+  const [imageSrc, setImageSrc] = useState(localStorage.getItem("pdfData")!); // Keeps track of image URL
   const [activePage, setActivePage] = useState<ViewPage>("sideBySide");
   const [lastActivePage, setLastActivePage] = useState<ViewPage>("sideBySide");
   const [isGeorefValid, setIsGeorefValid] = useState(false);
@@ -51,28 +51,26 @@ export default function Editor() {
   //call the addProject function when the component mounts
   useEffect(() => {
     // Check if the image source from local storage is valid, else redirect to home page
-    if (typeof window !== "undefined") {
-      setImageSrc(localStorage.getItem("pdfData")!);
 
-      // If image source is null, redirect to home page
-      if (imageSrc === null) {
-        router.push("/");
-      }
-
-      // If image source is not null, create an image object to check if the image is valid
-      if (imageSrc !== null) {
-        const image = new Image();
-
-        image.onerror = () => {
-          router.push("/");
-        };
-
-        image.src = imageSrc;
-      }
+    // If image source is null, redirect to home page
+    if (imageSrc === null) {
+      router.push("/");
     }
 
-    // After image is loaded, add the project
-    addProject(projectName);
+    // If image source is not null, create an image object to check if the image is valid
+    if (imageSrc !== null) {
+      const image = new Image();
+
+      image.onerror = () => {
+        router.push("/");
+      };
+
+      image.onload = () => {
+        addProject(projectName);
+      };
+
+      image.src = imageSrc;
+    }
   }, []);
 
   //function to add a new project


### PR DESCRIPTION
Moved the window check back to editor page, now redirects if the window is undefined/not in browser.

Added onload check which now only adds the project if the image is valid.