### PR TITLE
Changed Editor component to be dynamic

### DIFF
--- a/frontend/app/Editor/page.tsx
+++ b/frontend/app/Editor/page.tsx
@@ -6,6 +6,7 @@ const DynamicEditor = dynamic(
   { ssr: false }
 );
 
+// This comment is added here because GitHub is hanging at "Checking for ability to merge automatically…"
 export default function Page() {
   return (
     <main>

--- a/frontend/app/Editor/page.tsx
+++ b/frontend/app/Editor/page.tsx
@@ -1,16 +1,15 @@
 'use client';
-import Editor from '../../components/component/editor';
-import { useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
+
+const DynamicEditor = dynamic(
+  () => import('../../components/component/editor'),
+  { ssr: false }
+);
 
 export default function Page() {
-    const router = useRouter();
-    // check window object to see if we are in the browser or not then redirect to the home page
-    if (typeof window == 'undefined') {
-        router.push('/');
-    }
-    return (
-        <main>
-            {typeof window !== 'undefined' ? <Editor /> : null} 
-        </main>
-    );
+  return (
+    <main>
+      <DynamicEditor />
+    </main>
+  );
 }


### PR DESCRIPTION
New PR because last was hanging - lets try again
---
This PR just changes the Editor component to be dynamic, so we can set server side rendering to false. This _should_ fix the prod frontend build errors _(hopefully)_

Tested locally on docker