### PR TITLE
Implemented AWS S3 storage functionality

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,7 +8,7 @@ DATABASE_URL="postgresql://[user[:password]@][netloc][:port][/dbname]" # insert 
 
 # AWS S3 bucket configuration
 # Commented by default, uncomment and fill in the values to enable AWS S3 bucket
-#AWS_S3_BUCKET_NAME="bucket-name"
-#AWS_S3_DEFAULT_REGION="region"
-#AWS_S3_ACCESS_KEY_ID="access-key-id"
-#AWS_S3_SECRET_ACCESS_KEY="secret-access-key"
+#AWS_BUCKET_NAME="bucket-name"
+#AWS_DEFAULT_REGION="region"
+#AWS_ACCESS_KEY_ID="access-key-id"
+#AWS_SECRET_ACCESS_KEY="secret-access-key"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,9 +6,11 @@ ENVIRONMENT="development"
 # Local development if you are using docker-compose the host/netloc is host.docker.internal
 DATABASE_URL="postgresql://[user[:password]@][netloc][:port][/dbname]" # insert your database url here more info at https://www.postgresql.org/docs/9.2/libpq-connect.html#LIBPQ-CONNSTRING
 
+#Storage types are: "local", "aws" (defaults to local if not set)
+STORAGE_TYPE="local"
+
 # AWS S3 bucket configuration
-# Commented by default, uncomment and fill in the values to enable AWS S3 bucket
-#AWS_BUCKET_NAME="bucket-name"
-#AWS_DEFAULT_REGION="region"
-#AWS_ACCESS_KEY_ID="access-key-id"
-#AWS_SECRET_ACCESS_KEY="secret-access-key"
+AWS_BUCKET_NAME="bucket-name"
+AWS_DEFAULT_REGION="region"
+AWS_ACCESS_KEY_ID="access-key-id"
+AWS_SECRET_ACCESS_KEY="secret-access-key"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,3 +5,10 @@ ENVIRONMENT="development"
 #The url of the database you want to connect to the exaple is for postgresql
 # Local development if you are using docker-compose the host/netloc is host.docker.internal
 DATABASE_URL="postgresql://[user[:password]@][netloc][:port][/dbname]" # insert your database url here more info at https://www.postgresql.org/docs/9.2/libpq-connect.html#LIBPQ-CONNSTRING
+
+# AWS S3 bucket configuration
+# Commented by default, uncomment and fill in the values to enable AWS S3 bucket
+#AWS_S3_BUCKET_NAME="bucket-name"
+#AWS_S3_DEFAULT_REGION="region"
+#AWS_S3_ACCESS_KEY_ID="access-key-id"
+#AWS_S3_SECRET_ACCESS_KEY="secret-access-key"

--- a/backend/img2mapAPI/routers/georefProject.py
+++ b/backend/img2mapAPI/routers/georefProject.py
@@ -19,9 +19,10 @@ The module contains the following endpoints:
 """
 
 import os
+import io
 from typing import List
 from fastapi import APIRouter, File, UploadFile, HTTPException, BackgroundTasks
-from fastapi.responses import FileResponse, Response
+from fastapi.responses import FileResponse, Response, StreamingResponse
 #internal imports:
 from ..utils.models.point import Point
 from ..utils.models.project import Project
@@ -54,13 +55,16 @@ else:
     print("Using SQLite database")
 #TODO: Add a dependency class to handle errors and return the correct status code
 
+_Filestorage: FileStorage = LocalFileStorage()
+
 # Decide which file storage to use based on environment variables
-if 'AWS_S3_BUCKET_NAME' and 'AWS_S3_DEFAULT_REGION' and 'AWS_S3_ACCESS_KEY_ID' and 'AWS_S3_SECRET_ACCESS_KEY' in os.environ:
+if 'AWS_BUCKET_NAME' and 'AWS_DEFAULT_REGION' and 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_ACCESS_KEY' in os.environ:
     _Filestorage: FileStorage = S3FileStorage(os.environ['AWS_BUCKET_NAME'], os.environ['AWS_REGION_NAME'], os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'])
     print("Using AWS S3 file storage")
 else:
-    _Filestorage: FileStorage = LocalFileStorage()
     print("Using local file storage")
+#_TestFilestorage: FileStorage = S3FileStorage(os.environ['AWS_BUCKET_NAME'], os.environ['AWS_REGION_NAME'], os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'])
+#_testProjectHandler = ProjectHandler(_TestFilestorage, _StorageHandler)
 
 _projectHandler = ProjectHandler(_Filestorage, _StorageHandler)
 

--- a/backend/img2mapAPI/routers/georefProject.py
+++ b/backend/img2mapAPI/routers/georefProject.py
@@ -197,8 +197,9 @@ async def InitalgeorefImage(projectId: int, crs: str = None):
     """ Georeference the image of a project by project id, returns the georeferenced image file if found"""
     try:
         await _projectHandler.georefPNGImage(projectId, crs)
-        imagepath = await _projectHandler.getGeoreferencedFilePath(projectId)
-        return FileResponse(imagepath, media_type="image/tiff", filename="georeferenced.tiff")
+        imageBytes = await _projectHandler.getGeoreferencedFile(projectId)
+        return StreamingResponse(io.BytesIO(imageBytes), media_type="image/tiff", headers={"Content-Disposition": "attachment; filename=georeferenced.tiff"})
+        #return FileResponse(imagepath, media_type="image/tiff", filename="georeferenced.tiff")
     except Exception as e:
         raise HTTPException(status_code=404, detail=str(e))
 

--- a/backend/img2mapAPI/routers/georefProject.py
+++ b/backend/img2mapAPI/routers/georefProject.py
@@ -56,16 +56,18 @@ else:
     print("Using SQLite database")
 #TODO: Add a dependency class to handle errors and return the correct status code
 
+# Default to local file storage
 _Filestorage: FileStorage = LocalFileStorage()
 
-# Decide which file storage to use based on environment variables
-if 'AWS_BUCKET_NAME' and 'AWS_DEFAULT_REGION' and 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_ACCESS_KEY' in os.environ:
+# Decide which file storage to use based on environment variable
+if os.environ['STORAGE_TYPE'] == 'aws':
     _Filestorage: FileStorage = S3FileStorage(os.environ['AWS_BUCKET_NAME'], os.environ['AWS_REGION_NAME'], os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'])
     print("Using AWS S3 file storage")
-else:
+if os.environ['STORAGE_TYPE'] == 'local':
+    #This seems a bit redundant, but it is to explicitly state that local storage has been chosen
     print("Using local file storage")
-#_TestFilestorage: FileStorage = S3FileStorage(os.environ['AWS_BUCKET_NAME'], os.environ['AWS_REGION_NAME'], os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'])
-#_testProjectHandler = ProjectHandler(_TestFilestorage, _StorageHandler)
+else:
+    print("Defaulting to using local file storage")
 
 _projectHandler = ProjectHandler(_Filestorage, _StorageHandler)
 

--- a/backend/img2mapAPI/routers/georefProject.py
+++ b/backend/img2mapAPI/routers/georefProject.py
@@ -29,6 +29,7 @@ from ..utils.projectHandler import ProjectHandler
 from ..utils.core.georefHelper import generateTile
 from ..utils.storage.files.fileStorage import FileStorage
 from ..utils.storage.files.localFileStorage import LocalFileStorage
+from ..utils.storage.files.s3FileStorage import S3FileStorage
 from ..utils.storage.data.storageHandler import StorageHandler
 from ..utils.storage.data.sqliteLocalStorage import SQLiteStorage
 from ..utils.storage.data.postgresSqlHandler import PostgresSqlHandler
@@ -53,7 +54,13 @@ else:
     print("Using SQLite database")
 #TODO: Add a dependency class to handle errors and return the correct status code
 
-_Filestorage: FileStorage = LocalFileStorage()
+# Decide which file storage to use based on environment variables
+if 'AWS_S3_BUCKET_NAME' and 'AWS_S3_DEFAULT_REGION' and 'AWS_S3_ACCESS_KEY_ID' and 'AWS_S3_SECRET_ACCESS_KEY' in os.environ:
+    _Filestorage: FileStorage = S3FileStorage(os.environ['AWS_BUCKET_NAME'], os.environ['AWS_REGION_NAME'], os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'])
+    print("Using AWS S3 file storage")
+else:
+    _Filestorage: FileStorage = LocalFileStorage()
+    print("Using local file storage")
 
 _projectHandler = ProjectHandler(_Filestorage, _StorageHandler)
 

--- a/backend/img2mapAPI/routers/georefProject.py
+++ b/backend/img2mapAPI/routers/georefProject.py
@@ -220,14 +220,15 @@ async def getImageCoordinates(projectId: int):
         imageCoordinates = await _projectHandler.getImageCoordinates(projectId)
         return imageCoordinates
     except Exception as e:
+        print(e)
         raise HTTPException(status_code=404, detail=str(e))
 
 @router.get("/{projectId}/tiles/{z}/{x}/{y}.png", response_class=Response)
 async def getTile(projectId: int, z: int, x: int, y: int):
     """ Retrieve a tile from the georeferenced image of a project by project id, zoom level, x, and y coordinates, returns the tile if found"""
     try:
-        tiff_path = await _projectHandler.getGeoreferencedFilePath(projectId)
-        tile = await generateTile(tiff_path, x, y, z)
+        tiff_data = await _projectHandler.getGeoreferencedFile(projectId)
+        tile = await generateTile(tiff_data, x, y, z)
         return tile
     except Exception as e:
         # Handle unexpected errors

--- a/backend/img2mapAPI/utils/core/georefHelper.py
+++ b/backend/img2mapAPI/utils/core/georefHelper.py
@@ -3,6 +3,7 @@
 
 import os 
 import io 
+import tempfile
 import warnings
 import numpy as np
 import rasterio as rio 
@@ -143,11 +144,11 @@ def getImageCoordinates(tiff_path):
 
 
 
-async def generateTile(tiff_path, x: int, y: int, z: int):
+async def generateTile(tiff_bytes: bytes, x: int, y: int, z: int):
     """Generate a tile image from a georeferenced TIFF file.
 
     Args:
-        tiff_path (str): Path to the georeferenced TIFF file.
+        tiff_bytes (bytes): TIFF file as bytes.
         x (int): column index of the tile.
         y (int): row index of the tile.
         z (int): Zoom level of the tile.
@@ -159,16 +160,19 @@ async def generateTile(tiff_path, x: int, y: int, z: int):
         Respone: A FastAPI Response object containing the tile image as PNG bytes.
     """
 
-    blanke_tile = Image.new('RGBA', (256, 256), (255, 255, 255, 0))
+    blank_tile = Image.new('RGBA', (256, 256), (255, 255, 255, 0))
     bytes_io = io.BytesIO()
-    blanke_tile.save(bytes_io, format='PNG')
+    blank_tile.save(bytes_io, format='PNG')
     blank_tile_bytes = bytes_io.getvalue()
 
     MAX_ZOOM = 5
     if z < MAX_ZOOM:
         return Response(content=blank_tile_bytes, media_type="image/png")
     try:
-        with Reader(tiff_path) as src:
+        with tempfile.NamedTemporaryFile(delete=False) as temp:
+            temp.write(tiff_bytes)
+            temp_path = temp.name
+        with Reader(temp_path) as src:
                 tile, mask = src.tile(x, y, z) 
                 tile = np.moveaxis(tile, 0, -1)  
                 mask = np.expand_dims(mask, axis=-1)  

--- a/backend/img2mapAPI/utils/projectHandler.py
+++ b/backend/img2mapAPI/utils/projectHandler.py
@@ -12,6 +12,7 @@ from img2mapAPI.utils.models.pointList import PointList
 from .storage.files.fileStorage import FileStorage
 from .storage.data.storageHandler import StorageHandler
 from .core import georefHelper as georef
+from .core.FileHelper import removeFile
 import datetime
 
 class ProjectHandler:
@@ -513,28 +514,35 @@ class ProjectHandler:
             crs (str, optional): Cordinate refrence system. Defaults to None.
         """
 
+        #get the project and read the image file
         project = await self.getProject(projectId)
+        imageBytes = await self._FileStorage.readFile(project.imageFilePath)
 
-        imageFile = await self._FileStorage.readFile(project.imageFilePath)
-        with tempfile.NamedTemporaryFile(delete=False) as temp:
-            temp.write(imageFile)
-            temp_path = temp.name
+        #write the image bytes to a temporary image file
+        with tempfile.NamedTemporaryFile(delete=False) as temp_image:
+            temp_image.write(imageBytes)
+            temp_image_path = temp_image.name
 
+        #get the points of the project and georeference the image
         points : PointList = project.points
-        georeferencedImage = None
+        temp_georeferenced_image = None
         if crs is None:
-            georeferencedImage = georef.InitialGeoreferencePngImage(temp_path, points) #goreference the image, return the path to the georeferenced file
+            temp_georeferenced_image = georef.InitialGeoreferencePngImage(temp_image_path, points) #goreference the image, return the path to the georeferenced file
         else:
-            georeferencedImage = georef.InitialGeoreferencePngImage(temp_path, points, crs) #goreference the image, return the path to the georeferenced file
-        
-        if georeferencedImage is None:
+            temp_georeferenced_image = georef.InitialGeoreferencePngImage(temp_image_path, points, crs) #goreference the image, return the path to the georeferenced file
+
+        #we are done with the temporary image file, remove it
+        removeFile(temp_image_path)
+
+        # if for some reason the image could not be georeferenced, raise an exception
+        if temp_georeferenced_image is None:
             raise Exception("Image could not be georeferenced")
         
-        with open(georeferencedImage, 'rb') as file:
-            georeferencedImageBytes = file.read()
-
-        await self._FileStorage.removeFile(georeferencedImage)
-        await self.saveGeoreferencedFile(projectId, georeferencedImageBytes, "tiff")
+        #get the bytes of the georeferenced image, remove the temporary file and save the bytes to storage
+        with open(temp_georeferenced_image, 'rb') as file:
+            georeferenced_image_bytes = file.read()
+        removeFile(temp_georeferenced_image)
+        await self.saveGeoreferencedFile(projectId, georeferenced_image_bytes, "tiff")
 
     async def getImageCoordinates(self, projectId: int):
         """Get the corner coordinates of the image of a project
@@ -546,16 +554,21 @@ class ProjectHandler:
             [west, north, east south]: A list of corner coordinates in the order
         """
 
+        # get the project and read the image file
         project = await self.getProject(projectId)
-        imageFilePath = project.georeferencedFilePath
-        imageBytes = await self._FileStorage.readFile(imageFilePath)
+        image = project.georeferencedFilePath
+        image_bytes = await self._FileStorage.readFile(image)
         coordinates = None
 
+        # create a temporary file and get the image coordinates, then remove the temporary file
         with tempfile.NamedTemporaryFile(delete=False) as temp:
-            temp.write(imageBytes)
+            temp.write(image_bytes)
             temp_path = temp.name
+            temp.close()
             coordinates = georef.getImageCoordinates(temp_path)
-            
+            removeFile(temp_path)
+
+        # if the coordinates could not be found, raise an exception, otherwise return the coordinates
         if coordinates is None:
             raise Exception("Coordinates not found")
         return coordinates

--- a/backend/img2mapAPI/utils/storage/files/__init__.py
+++ b/backend/img2mapAPI/utils/storage/files/__init__.py
@@ -3,9 +3,11 @@
 Modules:
     - fileStorage: Contains the abstract base class for file storage
     - localFileStorage: Contains the local file storage implementation
+    - s3FileStorage: Contains the AWS S3 file storage implementation
 """
 
 from . import fileStorage
 from . import localFileStorage
+from . import s3FileStorage
 
-__All__ = ["fileStorage", "localFileStorage"]
+__All__ = ["fileStorage", "localFileStorage", "s3FileStorage"]

--- a/backend/img2mapAPI/utils/storage/files/s3FileStorage.py
+++ b/backend/img2mapAPI/utils/storage/files/s3FileStorage.py
@@ -1,0 +1,60 @@
+from .fileStorage import FileStorage
+import tempfile
+import boto3
+
+class S3FileStorage(FileStorage):
+
+    _instance = None
+
+    s3 = None
+    aws_bucket_name = None
+    aws_region_name = None
+    aws_access_key_id = None
+    aws_secret_access_key = None
+
+    async def saveFile(self, data: tempfile , suffix: str) -> str:
+        # Generate a unique filename
+        # Statistically improbable to have a collision, but not impossible (1 in 3.4 x 10^38 chance)
+        import secrets
+        filename = f"{secrets.token_hex(16)}.{suffix}"
+
+        # Upload the file to S3 bucket
+        self.s3.put_object(
+            Key=filename,
+            Body=data
+        )
+
+        # Return the S3 object URL
+        return f"https://{self.aws_bucket_name}.s3.amazonaws.com/{filename}"
+    
+    async def removeFile(self, path: str):
+        pass
+
+    async def readFile(self, path: str)->bytes:
+        pass
+
+    async def fileExists(self, path: str)->bool:
+        pass
+
+    async def saveFileFromPath(self, path: str, suffix: str)->str:
+        pass
+
+    def __init__(self, aws_bucket_name, aws_region_name, aws_access_key_id, aws_secret_access_key):
+        self.aws_bucket_name = aws_bucket_name
+        self.aws_region_name = aws_region_name
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
+
+        self.s3 = boto3.resource(
+            bucket_name=self.aws_bucket_name,
+            region_name=self.aws_region_name,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key
+        )
+
+    def __new__(cls, aws_bucket_name, aws_region_name, aws_access_key_id, aws_secret_access_key):
+        # If the instance does not exist, create it, otherwise return the instance
+        if cls._instance is None:
+            cls._instance = super(S3FileStorage, cls).__new__(cls)
+            cls.__init__(cls, aws_bucket_name, aws_region_name, aws_access_key_id, aws_secret_access_key)
+        return cls._instance

--- a/backend/img2mapAPI/utils/storage/files/s3FileStorage.py
+++ b/backend/img2mapAPI/utils/storage/files/s3FileStorage.py
@@ -17,7 +17,10 @@ class S3FileStorage(FileStorage):
     async def saveFile(self, data: tempfile , suffix: str) -> str:
         # Generate a unique filename
         import uuid
-        object_key = f"{uuid.uuid4()}.{suffix}"
+        if '.' in suffix:
+            object_key = f"{uuid.uuid4()}{suffix}"
+        else:
+            object_key = f"{uuid.uuid4()}.{suffix}"
 
         # Upload the file to S3 bucket
         self.bucket.put_object(

--- a/backend/img2mapAPI/utils/storage/files/s3FileStorage.py
+++ b/backend/img2mapAPI/utils/storage/files/s3FileStorage.py
@@ -1,12 +1,14 @@
 from .fileStorage import FileStorage
 import tempfile
 import boto3
+import botocore
 
 class S3FileStorage(FileStorage):
 
     _instance = None
 
     s3 = None
+    bucket = None
     aws_bucket_name = None
     aws_region_name = None
     aws_access_key_id = None
@@ -14,43 +16,65 @@ class S3FileStorage(FileStorage):
 
     async def saveFile(self, data: tempfile , suffix: str) -> str:
         # Generate a unique filename
-        # Statistically improbable to have a collision, but not impossible (1 in 3.4 x 10^38 chance)
-        import secrets
-        filename = f"{secrets.token_hex(16)}.{suffix}"
+        import uuid
+        object_key = f"{uuid.uuid4()}.{suffix}"
 
         # Upload the file to S3 bucket
-        self.s3.put_object(
-            Key=filename,
+        self.bucket.put_object(
+            Key=object_key,
             Body=data
         )
 
         # Return the S3 object URL
-        return f"https://{self.aws_bucket_name}.s3.amazonaws.com/{filename}"
+        return object_key
     
-    async def removeFile(self, path: str):
-        pass
+    async def removeFile(self, object_key: str):
+        # Remove the file from the S3 bucket
+        self.s3.Object(self.aws_bucket_name, object_key).delete()
 
-    async def readFile(self, path: str)->bytes:
-        pass
+    async def readFile(self, object_key: str)->bytes:
+        # Read the file from the S3 bucket and return it as bytes
+        response = self.bucket.Object(object_key).get()
+        data = response['Body'].read()
 
-    async def fileExists(self, path: str)->bool:
-        pass
+        return data
+
+    async def fileExists(self, object_key: str)->bool:
+        # Thefted from https://stackoverflow.com/a/33843019
+        # Try to load the object from S3 bucket using key, if it fails with 404 error, return False
+        try: 
+            self.s3.Object(self.aws_bucket_name, object_key).load()
+        except botocore.exceptions.ClientError as e:
+            if e.response['Error']['Code'] == "404":
+                return False
+            else:
+                raise
+
+        return True
 
     async def saveFileFromPath(self, path: str, suffix: str)->str:
-        pass
+        # This is thefted from localFileStorage.saveFileFromPath
+        with open(path, "rb") as file:
+            data = file.read()
+            return await self.saveFile(data, suffix)
 
     def __init__(self, aws_bucket_name, aws_region_name, aws_access_key_id, aws_secret_access_key):
+        # Store the provided credentials
         self.aws_bucket_name = aws_bucket_name
         self.aws_region_name = aws_region_name
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
 
+        # Create an S3 resource object using the provided credentials
         self.s3 = boto3.resource(
-            bucket_name=self.aws_bucket_name,
+            service_name='s3',
             region_name=self.aws_region_name,
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key
         )
+
+        # Create a reference to the specified bucket
+        self.bucket = self.s3.Bucket(self.aws_bucket_name)
 
     def __new__(cls, aws_bucket_name, aws_region_name, aws_access_key_id, aws_secret_access_key):
         # If the instance does not exist, create it, otherwise return the instance

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "python-dotenv",
     "poppler-utils",
     "psycopg2-binary",
+    "boto3",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,5 +9,6 @@ rio-tiler
 python-dotenv
 poppler-utils
 psycopg2-binary
+boto3
 
 ###### Requirements with Version Specifiers ######


### PR DESCRIPTION
This PR introduces AWS S3 buckets as storage, and fixes quirks related to the original implementation of local storage. 

### Changelog
**.env.example**
- Added STORAGE_TYPE, used for switching between storage types
- Added AWS S3 bucket config variables

**routers/georefProject**
- Created section to choose storage type based on env
- Updated various routes to use bytes rather than file paths
- getTile now returns a FastAPI response rather than a direct tile

**utils/core/georefHelper**
- generateTile now takes bytes rather than a file path
- generateTile now returns a tuple with bytes and path to temp file rather than a FastAPI response

**utils/projectHandler**
- Various changes to use bytes rather than file paths. 

**utils/storage/files/s3FileStorage**
- Adds AWS S3 bucket storage as a file storage implementation, based on the abstract fileStorage-class

**pyproject.toml and requirements.txt**
- Updated to include boto3