### PR TITLE
Implemented AWS S3 storage functionality++

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
           echo "HOST_PORT=8000" > backend/.env
           echo "CORS_ORIGINS='http://localhost,${{ vars.CORS_ORIGINS }}'" >> backend/.env
           echo "ENVIRONMENT='production'" >> backend/.env
+          echo "STORAGE_TYPE='bucketeer-s3'" >> backend/.env
       
       #TODO: add tests step
       #build backend docker image

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,3 +5,12 @@ ENVIRONMENT="development"
 #The url of the database you want to connect to the exaple is for postgresql
 # Local development if you are using docker-compose the host/netloc is host.docker.internal
 DATABASE_URL="postgresql://[user[:password]@][netloc][:port][/dbname]" # insert your database url here more info at https://www.postgresql.org/docs/9.2/libpq-connect.html#LIBPQ-CONNSTRING
+
+#Storage types are: "local", "aws" (defaults to local if not set)
+STORAGE_TYPE="local"
+
+# AWS S3 bucket configuration
+AWS_BUCKET_NAME="bucket-name"
+AWS_DEFAULT_REGION="region"
+AWS_ACCESS_KEY_ID="access-key-id"
+AWS_SECRET_ACCESS_KEY="secret-access-key"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,7 +6,7 @@ ENVIRONMENT="development"
 # Local development if you are using docker-compose the host/netloc is host.docker.internal
 DATABASE_URL="postgresql://[user[:password]@][netloc][:port][/dbname]" # insert your database url here more info at https://www.postgresql.org/docs/9.2/libpq-connect.html#LIBPQ-CONNSTRING
 
-#Storage types are: "local", "aws" (defaults to local if not set)
+#Storage types are: "local", "aws", "bucketeer-s3" (defaults to local if not set)
 STORAGE_TYPE="local"
 
 # AWS S3 bucket configuration
@@ -14,3 +14,9 @@ AWS_BUCKET_NAME="bucket-name"
 AWS_DEFAULT_REGION="region"
 AWS_ACCESS_KEY_ID="access-key-id"
 AWS_SECRET_ACCESS_KEY="secret-access-key"
+
+# Bucketeer AWS S3 bucket configuration
+BUCKETEER_BUCKET_NAME="bucket-name"
+BUCKETEER_AWS_REGION="region"
+BUCKETEER_AWS_ACCESS_KEY_ID="access-key-id"
+BUCKETEER_AWS_SECRET_ACCESS_KEY="secret-access"

--- a/backend/img2mapAPI/routers/georefProject.py
+++ b/backend/img2mapAPI/routers/georefProject.py
@@ -64,7 +64,10 @@ _Filestorage: FileStorage = LocalFileStorage()
 if os.environ['STORAGE_TYPE'] == 'aws':
     _Filestorage: FileStorage = S3FileStorage(os.environ['AWS_BUCKET_NAME'], os.environ['AWS_REGION_NAME'], os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'])
     print("Using AWS S3 file storage")
-if os.environ['STORAGE_TYPE'] == 'local':
+elif os.environ['STORAGE_TYPE'] == 'bucketeer-s3':
+    _Filestorage: FileStorage = S3FileStorage(os.environ['BUCKETEER_BUCKET_NAME'],os.environ['BUCKETEER_AWS_REGION'],os.environ['BUCKETEER_AWS_ACCESS_KEY_ID'],os.environ['BUCKETEER_AWS_SECRET_ACCESS_KEY'])
+    print("Using AWS S3 file storage through Bucketeer")
+elif os.environ['STORAGE_TYPE'] == 'local':
     #This seems a bit redundant, but it is to explicitly state that local storage has been chosen
     print("Using local file storage")
 else:

--- a/backend/img2mapAPI/utils/storage/files/__init__.py
+++ b/backend/img2mapAPI/utils/storage/files/__init__.py
@@ -3,9 +3,11 @@
 Modules:
     - fileStorage: Contains the abstract base class for file storage
     - localFileStorage: Contains the local file storage implementation
+    - s3FileStorage: Contains the AWS S3 file storage implementation
 """
 
 from . import fileStorage
 from . import localFileStorage
+from . import s3FileStorage
 
-__All__ = ["fileStorage", "localFileStorage"]
+__All__ = ["fileStorage", "localFileStorage", "s3FileStorage"]

--- a/backend/img2mapAPI/utils/storage/files/s3FileStorage.py
+++ b/backend/img2mapAPI/utils/storage/files/s3FileStorage.py
@@ -1,0 +1,87 @@
+from .fileStorage import FileStorage
+import tempfile
+import boto3
+import botocore
+
+class S3FileStorage(FileStorage):
+
+    _instance = None
+
+    s3 = None
+    bucket = None
+    aws_bucket_name = None
+    aws_region_name = None
+    aws_access_key_id = None
+    aws_secret_access_key = None
+
+    async def saveFile(self, data: tempfile , suffix: str) -> str:
+        # Generate a unique filename
+        import uuid
+        if '.' in suffix:
+            object_key = f"{uuid.uuid4()}{suffix}"
+        else:
+            object_key = f"{uuid.uuid4()}.{suffix}"
+
+        # Upload the file to S3 bucket
+        self.bucket.put_object(
+            Key=object_key,
+            Body=data
+        )
+
+        # Return the S3 object URL
+        return object_key
+    
+    async def removeFile(self, object_key: str):
+        # Remove the file from the S3 bucket
+        self.s3.Object(self.aws_bucket_name, object_key).delete()
+
+    async def readFile(self, object_key: str)->bytes:
+        # Read the file from the S3 bucket and return it as bytes
+        response = self.bucket.Object(object_key).get()
+        data = response['Body'].read()
+
+        return data
+
+    async def fileExists(self, object_key: str)->bool:
+        # Thefted from https://stackoverflow.com/a/33843019
+        # Try to load the object from S3 bucket using key, if it fails with 404 error, return False
+        try: 
+            self.s3.Object(self.aws_bucket_name, object_key).load()
+        except botocore.exceptions.ClientError as e:
+            if e.response['Error']['Code'] == "404":
+                return False
+            else:
+                raise
+
+        return True
+
+    async def saveFileFromPath(self, path: str, suffix: str)->str:
+        # This is thefted from localFileStorage.saveFileFromPath
+        with open(path, "rb") as file:
+            data = file.read()
+            return await self.saveFile(data, suffix)
+
+    def __init__(self, aws_bucket_name, aws_region_name, aws_access_key_id, aws_secret_access_key):
+        # Store the provided credentials
+        self.aws_bucket_name = aws_bucket_name
+        self.aws_region_name = aws_region_name
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
+
+        # Create an S3 resource object using the provided credentials
+        self.s3 = boto3.resource(
+            service_name='s3',
+            region_name=self.aws_region_name,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key
+        )
+
+        # Create a reference to the specified bucket
+        self.bucket = self.s3.Bucket(self.aws_bucket_name)
+
+    def __new__(cls, aws_bucket_name, aws_region_name, aws_access_key_id, aws_secret_access_key):
+        # If the instance does not exist, create it, otherwise return the instance
+        if cls._instance is None:
+            cls._instance = super(S3FileStorage, cls).__new__(cls)
+            cls.__init__(cls, aws_bucket_name, aws_region_name, aws_access_key_id, aws_secret_access_key)
+        return cls._instance

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "python-dotenv",
     "poppler-utils",
     "psycopg2-binary",
+    "boto3",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,5 +9,6 @@ rio-tiler
 python-dotenv
 poppler-utils
 psycopg2-binary
+boto3
 
 ###### Requirements with Version Specifiers ######


### PR DESCRIPTION
This PR is pretty much the same as the one submitted to dev-workerbuild yesterday, but now to dev instead. It introduces AWS S3 buckets as storage, and fixes quirks related to the original implementation of local storage. In addition, support for using Heroku-addon "Bucketeer" has been added as a possible way to use S3 storage.

### Changelog
**Deploy to Heroku workflow**
- Set Env to use Bucketeer for storage

**.env.example**
- Added STORAGE_TYPE, used for switching between storage types
- Added AWS S3 bucket config variables
- Added Bucketeer AWS S3 bucket config variables

**routers/georefProject**
- Created section to choose storage type based on env (local, s3, bucketeer)
- Updated various routes to use bytes rather than file paths
- getTile now returns a FastAPI response rather than a direct tile

**utils/core/georefHelper**
- generateTile now takes bytes rather than a file path
- generateTile now returns a tuple with bytes and path to temp file rather than a FastAPI response

**utils/projectHandler**
- Various changes to use bytes rather than file paths. 

**utils/storage/files/s3FileStorage**
- Adds AWS S3 bucket storage as a file storage implementation, based on the abstract fileStorage-class

**pyproject.toml and requirements.txt**
- Updated to include boto3