### PR TITLE
Img endpoint error 500 fix

### DIFF
--- a/backend/img2mapAPI/routers/georefProject.py
+++ b/backend/img2mapAPI/routers/georefProject.py
@@ -197,9 +197,9 @@ async def uploadImage(projectId: int, file: UploadFile = File(...)):
 async def getImage(projectId: int):
     """Get the image of a project by project id, returns the image file if found"""
     try:
-        imagepath = await _projectHandler.getImageFilePath(projectId)
+        FileBytes = await _projectHandler.getImageFile(projectId)
         mediaType = "image/png"
-        return FileResponse(imagepath, media_type=mediaType)
+        return StreamingResponse(io.BytesIO(FileBytes), media_type=mediaType, headers={"Content-Disposition": "attachment; filename=image.png"})
     except Exception as e:
         raise HTTPException(status_code=404, detail=str(e))
 

--- a/backend/img2mapAPI/utils/projectHandler.py
+++ b/backend/img2mapAPI/utils/projectHandler.py
@@ -388,7 +388,7 @@ class ProjectHandler:
         
         project = await self._StorageHandler.fetchOne(projectId, "project")
         filePath = project["imageFilePath"]
-        file = await self._FileStorage.get(filePath)
+        file = await self._FileStorage.readFile(filePath)
         if file is None:
             raise Exception("File not found")
         return file
@@ -423,7 +423,12 @@ class ProjectHandler:
         project = await self._StorageHandler.fetchOne(projectId, "project")
 
         if "imageFilePath" in project and project["imageFilePath"]:
-            await self._FileStorage.removeFile(project["imageFilePath"])
+            try:
+                await self._FileStorage.removeFile(project["imageFilePath"])
+            except Exception as e:
+                path = project.get("imageFilePath")
+                print(f"Failed to remove old file with path: {path} :: Expetion: {e}, assuming file does not exist, continuing...")
+                pass
 
         filePath = await self._FileStorage.saveFile(file, ".png")
         project["imageFilePath"] = filePath

--- a/backend/img2mapAPI/utils/projectHandler.py
+++ b/backend/img2mapAPI/utils/projectHandler.py
@@ -427,7 +427,7 @@ class ProjectHandler:
                 await self._FileStorage.removeFile(project["imageFilePath"])
             except Exception as e:
                 path = project.get("imageFilePath")
-                print(f"Failed to remove old file with path: {path} :: Expetion: {e}, assuming file does not exist, continuing...")
+                print(f"Failed to remove old file with path: {path} :: Exception: {e}, assuming file does not exist, continuing...")
                 pass
 
         filePath = await self._FileStorage.saveFile(file, ".png")


### PR DESCRIPTION
Save img didn't have failsafe when trying to remove old file.

Getting img will now work with the new s3handler.